### PR TITLE
Fix updateOutputAsync bug with updating option value to Some

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -27,9 +27,15 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-    
+
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+
+    <!-- Disable automagic references for F# DotNet SDK -->
+    <!-- This will not do anything for other project types -->
+    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
@@ -130,7 +136,7 @@
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
             Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
           <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
           <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
@@ -163,7 +169,7 @@
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
-    
+
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>

--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -27,15 +27,9 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-
+    
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
-
-    <!-- Disable automagic references for F# DotNet SDK -->
-    <!-- This will not do anything for other project types -->
-    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
-    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
@@ -136,7 +130,7 @@
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
             Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
           <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
           <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
@@ -169,7 +163,7 @@
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
-
+    
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>

--- a/src/Dapper.FSharp/MSSQL.fs
+++ b/src/Dapper.FSharp/MSSQL.fs
@@ -262,7 +262,7 @@ module private Preparators =
     let prepareOutputUpdate<'Input, 'Output> (q:UpdateQuery<'Input>) =
         let fields = typeof<'Input> |> Reflection.getFields
         let outputFields = typeof<'Output> |> Reflection.getFields
-        let values = Reflection.getValues q.Value
+        let values = Reflection.getValues q.Value |> List.map Reflection.boxify
         // extract metadata
         let meta = WhereAnalyzer.getWhereMetadata [] q.Where
         let pars = (WhereAnalyzer.extractWhereParams meta) @ (List.zip fields values) |> Map.ofList

--- a/tests/Dapper.FSharp.Tests/MSSQL/DeleteTests.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/DeleteTests.fs
@@ -30,23 +30,6 @@ let tests (conn:IDbConnection) = Tests.testList "DELETE" [
         Expect.equal 9 (fromDb |> Seq.head |> fun (x:Persons.View) -> x.Position) ""
     }
 
-    testTask "Deletes and outputs single record" {
-        do! Persons.init conn
-        let rs = Persons.View.generate 10
-        let! _ =
-            insert {
-                table "Persons"
-                values rs
-            } |> conn.InsertAsync
-        let! fromDb =
-            delete {
-                table "Persons"
-                where (eq "Position" 10)
-            } |> conn.DeleteOutputAsync<Persons.View>
-        Expect.equal 1 (Seq.length fromDb) ""
-        Expect.equal 10 (fromDb |> Seq.head |> fun (x:Persons.View) -> x.Position) ""
-    }
-
     testTask "Deletes more records" {
         do! Persons.init conn
         let rs = Persons.View.generate 10
@@ -66,5 +49,46 @@ let tests (conn:IDbConnection) = Tests.testList "DELETE" [
                 table "Persons"
             } |> conn.SelectAsync<Persons.View>
         Expect.equal 6 (Seq.length fromDb) ""
+    }
+
+
+    /// OUTPUT tests
+
+    testTask "Deletes and outputs single record" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            delete {
+                table "Persons"
+                where (eq "Position" 10)
+            } |> conn.DeleteOutputAsync<Persons.View>
+        Expect.equal 1 (Seq.length fromDb) ""
+        Expect.equal 10 (fromDb |> Seq.head |> fun (x:Persons.View) -> x.Position) ""
+    }
+
+    testTask "Deletes and outputs multiple records" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! insertedPersonIds =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertOutputAsync
+        let personIds = insertedPersonIds |> Seq.map (fun (p:{| Id:System.Guid |}) -> p.Id) |> Seq.toList
+        let boxedPersonIds = personIds |> List.map box |> Seq.toList
+
+        let! deleted =
+            delete {
+                table "Persons"
+                where (isIn "Id" boxedPersonIds)
+            } |> conn.DeleteOutputAsync<Persons.View>
+        Expect.hasLength deleted 10 ""
+        deleted |> Seq.iter (fun (p:Persons.View) ->
+            Expect.isTrue (personIds |> List.exists ((=) p.Id)) "Deleted personId not found from inserted Ids")
     }
 ]

--- a/tests/Dapper.FSharp.Tests/MSSQL/InsertTests.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/InsertTests.fs
@@ -24,17 +24,6 @@ let tests (conn:IDbConnection) = Tests.testList "INSERT" [
         Expect.equal r (Seq.head fromDb) ""
     }
 
-    testTask "Inserts and outputs new record" {
-        do! Persons.init conn
-        let r = Persons.View.generate 1 |> List.head
-        let! fromDb =
-            insert {
-                table "Persons"
-                value r
-            } |> conn.InsertOutputAsync<Persons.View, Persons.View>
-        Expect.equal r (Seq.head fromDb) ""
-    }
-
     testTask "Inserts partial record" {
         do! Persons.init conn
         let r =
@@ -68,5 +57,65 @@ let tests (conn:IDbConnection) = Tests.testList "INSERT" [
                 orderBy "Position" Asc
             } |> conn.SelectAsync<Persons.View>
         Expect.equal rs (Seq.toList fromDb) ""
+    }
+
+    /// OUTPUT tests
+
+    testTask "Inserts and outputs single record" {
+        do! Persons.init conn
+        let r = Persons.View.generate 1 |> List.head
+        let! fromDb =
+            insert {
+                table "Persons"
+                value r
+            } |> conn.InsertOutputAsync<Persons.View, Persons.View> // Optional type specification
+        Expect.equal r (Seq.head fromDb) ""
+    }
+
+    testTask "Inserts and outputs multiple records" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! insertedPersons =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertOutputAsync
+        let generatedPositions = rs |> List.map (fun p -> p.Position)
+        Expect.hasLength insertedPersons 10 ""
+        insertedPersons |> Seq.iter (fun (p:Persons.View) ->
+            Expect.isTrue (generatedPositions |> List.exists ((=) p.Position)) "Insert output person position not found from generated positions")
+    }
+
+    testTask "Inserts and outputs subset of single record columns" {
+        do! Persons.init conn
+        let r = Persons.View.generate 1 |> List.head
+        let! fromDb =
+            insert {
+                table "Persons"
+                value r
+            } |> conn.InsertOutputAsync
+        Expect.equal r.Position (Seq.head fromDb |> fun (p:{| Position:int |}) -> p.Position) ""
+    }
+
+    testTask "Inserts row with None value and outputs record" {
+        do! Persons.init conn
+        let r = Persons.View.generate 1 |> List.head |> fun p -> { p with DateOfBirth = None }
+        let! fromDb =
+            insert {
+                table "Persons"
+                value r
+            } |> conn.InsertOutputAsync
+        Expect.equal r (Seq.head fromDb) ""
+    }
+
+    testTask "Inserts row with Some value and outputs record" {
+        do! Persons.init conn
+        let r = Persons.View.generate 1 |> List.head |> fun p -> { p with DateOfBirth = Some System.DateTime.UtcNow }
+        let! fromDb =
+            insert {
+                table "Persons"
+                value r
+            } |> conn.InsertOutputAsync
+        Expect.equal r (Seq.head fromDb) ""
     }
 ]

--- a/tests/Dapper.FSharp.Tests/MSSQL/InsertTests.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/InsertTests.fs
@@ -116,6 +116,7 @@ let tests (conn:IDbConnection) = Tests.testList "INSERT" [
                 table "Persons"
                 value r
             } |> conn.InsertOutputAsync
-        Expect.equal r (Seq.head fromDb) ""
+        Expect.isSome (fromDb |> Seq.head |> fun (x:Persons.View) -> x.DateOfBirth) ""
+        Expect.equal r.Id (Seq.head fromDb |> fun (p:Persons.View) -> p.Id) "" // Comparing Some <datetime> fails even though it is the same
     }
 ]

--- a/tests/Dapper.FSharp.Tests/MSSQL/UpdateTests.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/UpdateTests.fs
@@ -48,7 +48,7 @@ let tests (conn:IDbConnection) = Tests.testList "UPDATE" [
         let! fromDb =
             select {
                 table "Persons"
-                where (eq "LastName" "UPDATED")
+                where (eq "Position" 2)
             } |> conn.SelectAsync<Persons.View>
         Expect.isNone (fromDb |> Seq.head |> fun (x:Persons.View) -> x.DateOfBirth) ""
         Expect.equal 2 (fromDb |> Seq.head |> fun (x:Persons.View) -> x.Position) ""

--- a/tests/Dapper.FSharp.Tests/MSSQL/UpdateTests.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/UpdateTests.fs
@@ -31,9 +31,32 @@ let tests (conn:IDbConnection) = Tests.testList "UPDATE" [
         Expect.equal 2 (fromDb |> Seq.head |> fun (x:Persons.View) -> x.Position) ""
     }
 
-    testTask "Updates and outputs single records" {
+    testTask "Updates option field to None" {
         do! Persons.init conn
-        let rs = Persons.View.generate 10
+        let rs = Persons.View.generate 10 |> List.map (fun p -> { p with DateOfBirth = Some System.DateTime.UtcNow })
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! _ =
+            update {
+                table "Persons"
+                set {| DateOfBirth = None |}
+                where (eq "Position" 2)
+            } |> conn.UpdateAsync
+        let! fromDb =
+            select {
+                table "Persons"
+                where (eq "LastName" "UPDATED")
+            } |> conn.SelectAsync<Persons.View>
+        Expect.isNone (fromDb |> Seq.head |> fun (x:Persons.View) -> x.DateOfBirth) ""
+        Expect.equal 2 (fromDb |> Seq.head |> fun (x:Persons.View) -> x.Position) ""
+    }
+
+    testTask "Updates option field to Some" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10 |> List.map (fun p -> { p with DateOfBirth = None })
         let! _ =
             insert {
                 table "Persons"
@@ -42,10 +65,10 @@ let tests (conn:IDbConnection) = Tests.testList "UPDATE" [
         let! fromDb =
             update {
                 table "Persons"
-                set {| LastName = "UPDATED" |}
+                set {| DateOfBirth = Some System.DateTime.UtcNow |}
                 where (eq "Position" 2)
-            } |> conn.UpdateOutputAsync<{| LastName:string |}, Persons.View>
-        Expect.equal "UPDATED" (fromDb |> Seq.head |> fun (x:Persons.View) -> x.LastName) ""
+            } |> conn.UpdateOutputAsync
+        Expect.isSome (fromDb |> Seq.head |> fun (x:Persons.View) -> x.DateOfBirth) ""
         Expect.equal 2 (fromDb |> Seq.head |> fun (x:Persons.View) -> x.Position) ""
     }
 
@@ -71,4 +94,104 @@ let tests (conn:IDbConnection) = Tests.testList "UPDATE" [
             } |> conn.SelectAsync<Persons.View>
         Expect.equal 3 (Seq.length fromDb) ""
     }
+
+
+    /// OUTPUT tests
+
+    testTask "Updates and outputs single record" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            update {
+                table "Persons"
+                set {| LastName = "UPDATED" |}
+                where (eq "Position" 2)
+            } |> conn.UpdateOutputAsync<{| LastName:string |}, Persons.View> // Example how to explicitly declare types
+        Expect.equal "UPDATED" (fromDb |> Seq.head |> fun (x:Persons.View) -> x.LastName) ""
+        Expect.equal 2 (fromDb |> Seq.head |> fun (x:Persons.View) -> x.Position) ""
+    }
+
+    testTask "Updates and outputs multiple records" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! insertedPersonIds =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertOutputAsync<Persons.View, {| Id:System.Guid |}>
+        let personIds = insertedPersonIds |> Seq.map (fun (p:{| Id:System.Guid |}) -> p.Id) |> Seq.toList
+        let boxedPersonIds = personIds |> List.map box |> Seq.toList
+        let! updated =
+            update {
+                table "Persons"
+                set {| LastName = "UPDATED" |}
+                where (isIn "Id" boxedPersonIds)
+            } |> conn.UpdateOutputAsync // If we specify the output type after, we dont need to specify it here
+        Expect.hasLength updated 10 ""
+        updated |> Seq.iter (fun (p:Persons.View) -> // Output specified here
+            Expect.equal "UPDATED" (p.LastName) ""
+            Expect.isTrue (personIds |> List.exists ((=) p.Id)) "Updated personId not found from inserted Ids")
+    }
+
+    testTask "Updates and outputs subset of single record columns" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            update {
+                table "Persons"
+                set {| LastName = "UPDATED" |}
+                where (eq "Position" 2)
+            } |> conn.UpdateOutputAsync
+        let pos2Id = rs |> List.pick (fun p -> if p.Position = 2 then Some p.Id else None)
+        Expect.equal pos2Id (fromDb |> Seq.head |> fun (p:{| Id:System.Guid |}) -> p.Id) ""
+    }
+
+    testTask "Updates option field to None and outputs record" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10 |> List.map (fun p -> { p with DateOfBirth = Some System.DateTime.UtcNow })
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            update {
+                table "Persons"
+                set {| DateOfBirth = None |}
+                where (eq "Position" 2)
+            } |> conn.UpdateOutputAsync
+        Expect.isNone (fromDb |> Seq.head |> fun (x:Persons.View) -> x.DateOfBirth) ""
+        Expect.equal 2 (fromDb |> Seq.head |> fun (x:Persons.View) -> x.Position) ""
+    }
+
+    testTask "Updates option field to Some and outputs record" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10 |> List.map (fun p -> { p with DateOfBirth = None })
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            update {
+                table "Persons"
+                set {| DateOfBirth = Some System.DateTime.UtcNow |}
+                where (eq "Position" 2)
+            } |> conn.UpdateOutputAsync
+        Expect.isSome (fromDb |> Seq.head |> fun (x:Persons.View) -> x.DateOfBirth) ""
+        Expect.equal 2 (fromDb |> Seq.head |> fun (x:Persons.View) -> x.Position) ""
+    }
 ]
+
+
+ 


### PR DESCRIPTION
Issue: When using updateOutputAsync method with record with Option of value Some dapper throws an exception: Implicit conversion from data type sql_variant to <type> is not allowed.

Reproduce: I created a test case for this: "Updates option field to Some and outputs record". In the first commit this test still fails. With the second commit the test passes.

This PR fixes this issue with the same solution already applied to the normal outputAsync method which I apparently forgot to add to this updateOutputAsync method. Sorry. To make it up, I created a bunch more tests for the project.

Created a test for this issue in both normal update and updateOutput methods as well as updating to None.

Created tests for returning multiple rows with output methods.

Created tests for returning a column subset with output methods.

To make the tests easier to manage separated output method tests from normal tests.

Sorry again for the trouble :)