### PR TITLE
Add support for LIKE operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ select {
 } |> conn.SelectAsync<Person>
 ```
 
+To use LIKE operator in `where` condition, use `like`:
+
+```f#
+select {
+    table "Persons"
+    where (like "FirstName" "%partofname%")
+} |> conn.SelectAsync<Person>
+```
+
 Sorting works as you would expect:
 
 ```f#

--- a/src/Dapper.FSharp/Builders.fs
+++ b/src/Dapper.FSharp/Builders.fs
@@ -116,6 +116,8 @@ let lt name (o:obj) = column name (Lt o)
 let ge name (o:obj) = column name (Ge o)
 /// WHERE column value lower/equals than
 let le name (o:obj) = column name (Le o)
+/// WHERE column like value
+let like name (str:string) = column name (Like str)
 /// WHERE column is IN values
 let isIn name (os:obj list) = column name (In os)
 /// WHERE column is NOT IN values

--- a/src/Dapper.FSharp/Dapper.FSharp.fs
+++ b/src/Dapper.FSharp/Dapper.FSharp.fs
@@ -15,6 +15,7 @@ type ColumnComparison =
     | Le of obj
     | In of obj list
     | NotIn of obj list
+    | Like of string
     | IsNull
     | IsNotNull
 

--- a/src/Dapper.FSharp/MSSQL.fs
+++ b/src/Dapper.FSharp/MSSQL.fs
@@ -17,6 +17,7 @@ module private WhereAnalyzer =
             | Eq p | Ne p | Gt p
             | Lt p | Ge p | Le p -> (m.ParameterName, p) |> Some
             | In p | NotIn p -> (m.ParameterName, p :> obj) |> Some
+            | Like str -> (m.ParameterName, str :> obj) |> Some
             | IsNull | IsNotNull -> None
         meta
         |> List.choose fn
@@ -65,6 +66,7 @@ module private Evaluators =
             | Le _ -> withField "<="
             | In _ -> withField "IN"
             | NotIn _ -> withField "NOT IN"
+            | Like _ -> withField "LIKE"
             | IsNull -> sprintf "%s IS NULL" fieldMeta.Name
             | IsNotNull -> sprintf "%s IS NOT NULL" fieldMeta.Name
         | Binary(w1, comb, w2) ->


### PR DESCRIPTION
Adds support for string pattern search with LIKE operator.

Documented briefly in README.md and created a couple tests for the implementation.