### PR TITLE
Support for group by, distinct, and aggregate functions

### DIFF
--- a/src/Dapper.FSharp/Builders.fs
+++ b/src/Dapper.FSharp/Builders.fs
@@ -59,15 +59,21 @@ type SelectBuilder() =
     member __.Yield _ =
         {
             Table = ""
+            Distinct = false
             Where = Where.Empty
             OrderBy = []
             Pagination = Skip 0
             Joins = []
+            GroupBy = []
         } : SelectQuery
 
     /// Sets the TABLE name for query
     [<CustomOperation "table">]
     member __.Table (state:SelectQuery, name) = { state with Table = name }
+
+    /// Sets query to return distinct values
+    [<CustomOperation "distinct">]
+    member __.Distinct (state:SelectQuery) = { state with Distinct = true }
 
     /// Sets the WHERE condition
     [<CustomOperation "where">]
@@ -96,6 +102,11 @@ type SelectBuilder() =
     /// LEFT JOIN table where COLNAME equals to another COLUMN (including TABLE name)
     [<CustomOperation "leftJoin">]
     member __.LeftJoin (state:SelectQuery, tableName, colName, equalsTo) = { state with Joins = state.Joins @ [LeftJoin(tableName, colName, equalsTo)] }
+
+    /// Sets group by columns
+    [<CustomOperation "groupBy">]
+    member __.GroupBy (state:SelectQuery, columns) = { state with GroupBy = columns |> List.map GroupByColumn }
+
 
 let insert<'a> = InsertBuilder<'a>()
 let delete = DeleteBuilder()
@@ -126,3 +137,10 @@ let isNotIn name (os:obj list) = column name (NotIn os)
 let isNullValue name = column name IsNull
 /// WHERE column IS NOT NULL
 let isNotNullValue name = column name IsNotNull
+
+// Aggregate function builders
+let count column alias = Count (column, alias)
+let avg column alias = Avg (column, alias)
+let sum column alias = Sum (column, alias)
+let min column alias = Min (column, alias)
+let max column alias = Max (column, alias)

--- a/src/Dapper.FSharp/Dapper.FSharp.fs
+++ b/src/Dapper.FSharp/Dapper.FSharp.fs
@@ -35,6 +35,15 @@ type Where =
     static member (*) (a, b) = Binary(a, Or, b)
     static member (!!) a = Unary (Not, a)
 
+type GroupBy = GroupByColumn of string
+
+type Aggregate =
+    | Count of column:string * alias:string
+    | Avg of column:string * alias:string
+    | Sum of column:string * alias:string
+    | Min of column:string * alias:string
+    | Max of column:string * alias:string
+
 type Pagination =
     | Skip of skip:int
     | SkipTake of skip:int * take:int
@@ -50,10 +59,12 @@ module Join =
 
 type SelectQuery = {
     Table : string
+    Distinct : bool
     Where : Where
     OrderBy : OrderBy list
     Pagination : Pagination
     Joins : Join list
+    GroupBy : GroupBy list
 }
 
 type InsertQuery<'a> = {

--- a/tests/Dapper.FSharp.Tests/MSSQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/SelectTests.fs
@@ -435,4 +435,445 @@ let tests (conn:IDbConnection) = Tests.testList "SELECT" [
         Expect.equal None wn ""
         Expect.equal 16 (Seq.length fromDb) ""
     }
+
+
+    testTask "Select aggregate count on empty table" {
+        do! Persons.init conn
+        let! fromDb =
+            select {
+                table "Persons"
+            } |> fun query -> conn.SelectAsync<{| count:int |}>(query, aggr = [ count "*" "count" ])
+        Expect.equal 0 (fromDb |> Seq.head |> fun (x:{| count:int |}) -> x.count) ""
+    }
+
+    testTask "Select aggregate count" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"
+            } |> fun query -> conn.SelectAsync<{| count:int |}>(query, aggr = [ count "*" "count" ])
+        Expect.equal 10 (fromDb |> Seq.head |> fun (x:{| count:int |}) -> x.count) ""
+    }
+
+    testTask "Select aggregate count with column name" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"
+            } |> fun query -> conn.SelectAsync<{| count:int |}>(query, aggr = [ count "Position" "count" ])
+        Expect.equal 10 (fromDb |> Seq.head |> fun (x:{| count:int |}) -> x.count) ""
+    }
+
+    testTask "Select aggregate count with where condition" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"
+                where (eq "Position" 1)
+            } |> fun query -> conn.SelectAsync<{| count:int |}>(query, aggr = [ count "*" "count" ])
+        Expect.equal 1 (fromDb |> Seq.head |> fun (x:{| count:int |}) -> x.count) ""
+    }
+
+    testTask "Select aggregate avg with empty table" {
+        do! Persons.init conn
+        let! fromDb =
+            select {
+                table "Persons"
+            } |> fun query -> conn.SelectAsync<{| avg:int option |}>(query, aggr = [ avg "Position" "avg" ])
+        let result = fromDb |> Seq.head |> fun (x:{| avg:int option |}) -> x.avg
+        Expect.isNone result ""
+    }
+
+    testTask "Select aggregate avg" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"
+            } |> fun query -> conn.SelectAsync<{| avg:int option |}>(query, aggr = [ avg "Position" "avg" ])
+        let result = fromDb |> Seq.head |> fun (x:{| avg:int option |}) -> x.avg
+        Expect.isSome result ""
+        Expect.equal 5 result.Value ""
+    }
+
+    testTask "Select aggregate avg with where condition" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"
+                where (eq "Position" 1)
+            } |> fun query -> conn.SelectAsync<{| avg:int option |}>(query, aggr = [ avg "Position" "avg" ])
+        let result = fromDb |> Seq.head |> fun (x:{| avg:int option |}) -> x.avg
+        Expect.isSome result ""
+        Expect.equal 1 result.Value ""
+    }
+
+    testTask "Select aggregate sum with empty table" {
+        do! Persons.init conn
+        let! fromDb =
+            select {
+                table "Persons"
+            } |> fun query -> conn.SelectAsync<{| sum:int option |}>(query, aggr = [ sum "Position" "sum" ])
+        let result = fromDb |> Seq.head |> fun (x:{| sum:int option |}) -> x.sum
+        Expect.isNone result ""
+    }
+
+    testTask "Select aggregate sum" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"
+            } |> fun query -> conn.SelectAsync<{| sum:int option |}>(query, aggr = [ sum "Position" "sum" ])
+        let result = fromDb |> Seq.head |> fun (x:{| sum:int option |}) -> x.sum
+        Expect.isSome result ""
+        Expect.equal 55 result.Value ""
+    }
+
+    testTask "Select aggregate sum with where condition" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"
+                where (eq "Position" 1)
+            } |> fun query -> conn.SelectAsync<{| sum:int option |}>(query, aggr = [ sum "Position" "sum" ])
+        let result = fromDb |> Seq.head |> fun (x:{| sum:int option |}) -> x.sum
+        Expect.isSome result ""
+        Expect.equal 1 result.Value ""
+    }
+
+    testTask "Select aggregate min with empty table" {
+        do! Persons.init conn
+        let! fromDb =
+            select {
+                table "Persons"
+                where (eq "Position" 1)
+            } |> fun query -> conn.SelectAsync<{| min:int option |}>(query, aggr = [ min "Position" "min" ])
+        let result = fromDb |> Seq.head |> fun (x:{| min:int option |}) -> x.min
+        Expect.isNone result ""
+    }
+
+    testTask "Select aggregate min" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"
+            } |> fun query -> conn.SelectAsync<{| min:int option |}>(query, aggr = [ min "Position" "min" ])
+        let result = fromDb |> Seq.head |> fun (x:{| min:int option |}) -> x.min
+        Expect.isSome result ""
+        Expect.equal 1 result.Value ""
+    }
+
+    testTask "Select aggregate min with where condition" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"
+                where (eq "Position" 2) // Set the value not to the smallest one like others to make sure min works
+            } |> fun query -> conn.SelectAsync<{| min:int option |}>(query, aggr = [ min "Position" "min" ])
+        let result = fromDb |> Seq.head |> fun (x:{| min:int option |}) -> x.min
+        Expect.isSome result ""
+        Expect.equal 2 result.Value ""
+    }
+
+    testTask "Select aggregate max with empty table" {
+        do! Persons.init conn
+        let! fromDb =
+            select {
+                table "Persons"
+            } |> fun query -> conn.SelectAsync<{| max:int option |}>(query, aggr = [ max "Position" "max" ])
+        let result = fromDb |> Seq.head |> fun (x:{| max:int option |}) -> x.max
+        Expect.isNone result ""
+    }
+
+    testTask "Select aggregate max" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"
+            } |> fun query -> conn.SelectAsync<{| max:int option |}>(query, aggr = [ max "Position" "max" ])
+        let result = fromDb |> Seq.head |> fun (x:{| max:int option |}) -> x.max
+        Expect.isSome result ""
+        Expect.equal 10 result.Value ""
+    }
+
+    testTask "Select aggregate max with where condition" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"
+                where (eq "Position" 1)
+            } |> fun query -> conn.SelectAsync<{| max:int option |}>(query, aggr = [ max "Position" "max" ])
+        let result = fromDb |> Seq.head |> fun (x:{| max:int option |}) -> x.max
+        Expect.isSome result ""
+        Expect.equal 1 result.Value ""
+    }
+
+    testTask "Select aggregate multiple functions" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"               
+            } |> fun query ->
+                conn.SelectAsync<{| count:int; avg:int option; sum:int option; max:int option; min:int option |}>(
+                    query, [ avg "Position" "avg"; count "*" "count"; max "Position" "max"; min "Position" "min"; sum "Position" "sum" ])
+        let count, avg, sum, max, min = 
+            fromDb 
+            |> Seq.head 
+            |> fun (x:{| count:int; avg:int option; sum:int option; max:int option; min:int option |}) -> 
+                x.count, x.avg, x.sum, x.max, x.min
+        Expect.isSome avg ""
+        Expect.isSome sum ""
+        Expect.isSome min ""
+        Expect.isSome max ""
+
+        Expect.equal 10 count ""
+        Expect.equal 5 avg.Value ""
+        Expect.equal 55 sum.Value ""
+        Expect.equal 1 min.Value ""
+        Expect.equal 10 max.Value ""
+    }
+
+    testTask "Select aggregate multiple same function types" {
+        do! Persons.init conn
+        let rs = Persons.View.generate 10
+        let! _ =
+            insert {
+                table "Persons"
+                values rs
+            } |> conn.InsertAsync
+        let! fromDb =
+            select {
+                table "Persons"               
+            } |> fun query ->
+                conn.SelectAsync<{| countPositions1:int; countPositions2:int |}>(
+                    query, [ count "Position" "countPositions1"; count "Position" "countPositions2" ])
+        let pos1, pos2 = 
+            fromDb 
+            |> Seq.head 
+            |> fun (x:{| countPositions1:int; countPositions2:int |}) -> x.countPositions1, x.countPositions2
+
+        Expect.equal 10 pos1 ""
+        Expect.equal 10 pos2 ""
+    }
+
+    testTask "Select aggregate with inner joined query" {
+        do! Persons.init conn
+        do! Dogs.init conn
+
+        let persons = Persons.View.generate 10
+        let dogs = Dogs.View.generate1toN 5 persons.Head
+        let! _ =
+            insert {
+                table "Persons"
+                values persons
+            } |> conn.InsertAsync
+        let! _ =
+            insert {
+                table "Dogs"
+                values dogs
+            } |> conn.InsertAsync
+
+        let! fromDb =
+            select {
+                table "Persons"
+                innerJoin "Dogs" "OwnerId" "Persons.Id"
+            } |> fun query ->
+                conn.SelectAsync<{| count:int |}>(query, [ count "*" "count" ])
+        
+        let result = fromDb |> Seq.head |> fun (x:{| count:int |}) -> x
+        Expect.equal 5 result.count ""
+    }
+
+    testTask "Select aggregate with left joined query" {
+        do! Persons.init conn
+        do! Dogs.init conn
+
+        let persons = Persons.View.generate 10
+        let dogs = Dogs.View.generate1toN 5 persons.Head
+        let! _ =
+            insert {
+                table "Persons"
+                values persons
+            } |> conn.InsertAsync
+        let! _ =
+            insert {
+                table "Dogs"
+                values dogs
+            } |> conn.InsertAsync
+
+        let! fromDb =
+            select {
+                table "Persons"
+                leftJoin "Dogs" "OwnerId" "Persons.Id"
+            } |> fun query ->
+                conn.SelectAsync<{| count:int |}>(query, [ count "*" "count" ])
+        
+        let result = fromDb |> Seq.head |> fun (x:{| count:int |}) -> x
+        Expect.equal 14 result.count ""
+    }
+
+    testTask "Select group by aggregate" {
+        do! Persons.init conn
+        do! Dogs.init conn
+
+        let persons = Persons.View.generate 10
+        let dogs = Dogs.View.generate1toN 5 persons.Head
+        let! _ =
+            insert {
+                table "Persons"
+                values persons
+            } |> conn.InsertAsync
+        let! _ =
+            insert {
+                table "Dogs"
+                values dogs
+            } |> conn.InsertAsync
+
+        let! fromDb =
+            select {
+                table "Persons"
+                leftJoin "Dogs" "OwnerId" "Persons.Id"
+                groupBy [ "Persons.Position" ]
+            } |> fun query ->
+                conn.SelectAsync<{| position:int; count:int |}>(query, [ count "*" "count" ])
+        
+        fromDb 
+        |> Seq.iter (fun (x:{| position:int; count:int |}) -> 
+            if x.position = 1 // Only head has dogs created
+            then Expect.equal 5 x.count ""
+            else Expect.equal 1 x.count ""
+        )
+    }
+
+    testTask "Select group by aggregate with tupled result" {
+        do! Persons.init conn
+        do! Dogs.init conn
+
+        let persons = Persons.View.generate 10
+        let dogs = Dogs.View.generate1toN 5 persons.Head
+        let! _ =
+            insert {
+                table "Persons"
+                values persons
+            } |> conn.InsertAsync
+        let! _ =
+            insert {
+                table "Dogs"
+                values dogs
+            } |> conn.InsertAsync
+
+        let! fromDb =
+            select {
+                table "Persons"
+                leftJoin "Dogs" "OwnerId" "Persons.Id"
+                groupBy [ "Persons.Position"; "Dogs.OwnerId" ]
+            } |> fun query ->
+                conn.SelectAsync<{| position:int; count:int |}, {| ownerId:System.Guid |}>(query, [ count "Persons.Position" "count" ])
+        
+        fromDb 
+        |> Seq.iter (fun (a:{| position:int; count:int |}, _) -> 
+            if a.position = 1 // Only head has dogs created
+            then Expect.equal 5 a.count ""
+            else Expect.equal 1 a.count ""
+        )
+    }
+
+    testTask "Select distinct" {
+        do! Persons.init conn
+        do! Dogs.init conn
+
+        let persons = Persons.View.generate 10
+        let dogs = Dogs.View.generate1toN 5 persons.Head
+        let! _ =
+            insert {
+                table "Persons"
+                values persons
+            } |> conn.InsertAsync
+        let! _ =
+            insert {
+                table "Dogs"
+                values dogs
+            } |> conn.InsertAsync
+
+        let! fromDb =
+            select {
+                table "Persons"
+                distinct
+                leftJoin "Dogs" "OwnerId" "Persons.Id"
+            } |> conn.SelectAsync<{| firstName:string |}>
+        
+        Expect.equal 10 (fromDb |> Seq.length) ""
+        Expect.equal 10 (fromDb |> Seq.distinctBy (fun (x:{| firstName:string |}) -> x.firstName) |> Seq.length) ""
+    }
 ]


### PR DESCRIPTION
Hi, 

For this PR my original use case was to complement the awesome paging feature this library already had. 

The problem I have had with it is that usually when I create a paginated API, I would like to return a total row count for the given search filter. So far this was not possible by using the selectQueryBuilder of this library and I had to multiply the filter creation logic for both plain dapper query and for the paginated query using this library. 

One option would have been to just create a function to turn Where construct of this library into a normal string SQL and parameters that could be passed to Dapper. That way I would only need to implement the where building logic once and use it both Dapper and this library. Even though I think this feature would be good for better fallback support to plain dapper, I thought that basic aggregate functions support could be a useful addition for this library anyway. And once I started that path, making support for just count, seemed a bit silly. That's why I implemented the other basic aggregate functions and tried to implement them seamlessly to the existing select functions.

Since I had gotten this far, I thought that aggregate functions without a group by feature is a bit stump feature and since it is quite easy to implement I added support for it too. And the same goes for distinct support.

Still, support for having clause is missing, but making it work like where clause seemed a bit intimidating for now so I didn't implement it, but I think it would be a nice feature to go along with group by and aggregate functions eventually.

The one thing that bothers me with the aggregate function solution here is that when using joined queries it is not possible to use the special values (for example * in COUNT(*)) anymore since, there isn't enough information to bind the aggregate function to some output record field. For the simplicity of usage I did not go the extra mile to try to cover that caveat. Instead I tried to document the limitation to README. Do you have suggestions on how that part could be made better?