### PR TITLE
handle float32/single option type

### DIFF
--- a/src/Dapper.FSharp/OptionTypes.fs
+++ b/src/Dapper.FSharp/OptionTypes.fs
@@ -27,7 +27,7 @@ let register() =
     SqlMapper.AddTypeHandler (OptionHandler<int64>())
     SqlMapper.AddTypeHandler (OptionHandler<float>())
     SqlMapper.AddTypeHandler (OptionHandler<decimal>())
-    SqlMapper.AddTypeHandler (OptionHandler<double>())
+    SqlMapper.AddTypeHandler (OptionHandler<float32>())
     SqlMapper.AddTypeHandler (OptionHandler<string>())
     SqlMapper.AddTypeHandler (OptionHandler<char>())
     SqlMapper.AddTypeHandler (OptionHandler<DateTime>())


### PR DESCRIPTION
adding `float` and `double` is the same operation.  `float32`/`single` was not included.

This is what the decompiled code looks like prior to the change.  Note two calls to add `double`.
``` C#
  public static class OptionTypes
  {
    public static void register()
    {
      SqlMapper.AddTypeHandler<FSharpOption<Guid>>((SqlMapper.TypeHandler<FSharpOption<Guid>>) new OptionTypes.OptionHandler<Guid>());
      SqlMapper.AddTypeHandler<FSharpOption<byte>>((SqlMapper.TypeHandler<FSharpOption<byte>>) new OptionTypes.OptionHandler<byte>());
      SqlMapper.AddTypeHandler<FSharpOption<short>>((SqlMapper.TypeHandler<FSharpOption<short>>) new OptionTypes.OptionHandler<short>());
      SqlMapper.AddTypeHandler<FSharpOption<int>>((SqlMapper.TypeHandler<FSharpOption<int>>) new OptionTypes.OptionHandler<int>());
      SqlMapper.AddTypeHandler<FSharpOption<long>>((SqlMapper.TypeHandler<FSharpOption<long>>) new OptionTypes.OptionHandler<long>());
      SqlMapper.AddTypeHandler<FSharpOption<double>>((SqlMapper.TypeHandler<FSharpOption<double>>) new OptionTypes.OptionHandler<double>());
      SqlMapper.AddTypeHandler<FSharpOption<Decimal>>((SqlMapper.TypeHandler<FSharpOption<Decimal>>) new OptionTypes.OptionHandler<Decimal>());
      SqlMapper.AddTypeHandler<FSharpOption<double>>((SqlMapper.TypeHandler<FSharpOption<double>>) new OptionTypes.OptionHandler<double>());
      SqlMapper.AddTypeHandler<FSharpOption<string>>((SqlMapper.TypeHandler<FSharpOption<string>>) new OptionTypes.OptionHandler<string>());
      SqlMapper.AddTypeHandler<FSharpOption<char>>((SqlMapper.TypeHandler<FSharpOption<char>>) new OptionTypes.OptionHandler<char>());
      SqlMapper.AddTypeHandler<FSharpOption<DateTime>>((SqlMapper.TypeHandler<FSharpOption<DateTime>>) new OptionTypes.OptionHandler<DateTime>());
      SqlMapper.AddTypeHandler<FSharpOption<DateTimeOffset>>((SqlMapper.TypeHandler<FSharpOption<DateTimeOffset>>) new OptionTypes.OptionHandler<DateTimeOffset>());
      SqlMapper.AddTypeHandler<FSharpOption<bool>>((SqlMapper.TypeHandler<FSharpOption<bool>>) new OptionTypes.OptionHandler<bool>());
      SqlMapper.AddTypeHandler<FSharpOption<TimeSpan>>((SqlMapper.TypeHandler<FSharpOption<TimeSpan>>) new OptionTypes.OptionHandler<TimeSpan>());
    }
```