### PR TITLE
Preemptively fixed Linq support for Guid values

### DIFF
--- a/src/Dapper.FSharp/LinqExpressionVisitors.fs
+++ b/src/Dapper.FSharp/LinqExpressionVisitors.fs
@@ -131,6 +131,9 @@ module SqlPatterns =
     /// A constant value or an optional constant value
     let (|Value|_|) (exp: Expression) =
         match exp with
+        | New n when n.Type.Name = "Guid" -> 
+            let value = (n.Arguments.[0] :?> ConstantExpression).Value :?> string
+            Some (Guid(value) |> box)
         | Member m when m.Expression.NodeType = ExpressionType.Constant -> 
             // Extract constant value from property (probably a record property)
             // NOTE: This currently does not unwind nested properties! 

--- a/tests/Dapper.FSharp.Tests/LinqSelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/LinqSelectTests.fs
@@ -26,6 +26,12 @@ type Contact = {
     Phone: string
 }
 
+type Vehicle = {
+    Id: System.Guid
+    Make: string
+    Model: string
+}
+
 let unitTests() = testList "LINQ SELECT UNIT TESTS" [
     
     testTask "Most Simple Query" {
@@ -389,6 +395,16 @@ let unitTests() = testList "LINQ SELECT UNIT TESTS" [
         Expect.equal query.Joins [
             InnerJoin ("dbo.Addresses", "City", "dbo.People.MI")
         ] "Expected that option column (MI) should be unwrapped."
+    }
+    
+    testTask "Guid in Where" {
+        let query = 
+            select {
+                for v in table<Vehicle> do
+                where (v.Id = System.Guid("c586871d-3329-4fca-a231-fd11203a937d"))
+            }
+
+        Expect.equal query.Where (eq "Vehicle.Id" (System.Guid("c586871d-3329-4fca-a231-fd11203a937d"))) "Expected WHERE to contain a guid"
     }
 ]
 


### PR DESCRIPTION
This contains just the fix and an added test.