### PR TITLE
Fixes annoying Zero errors when typing joins.

### DIFF
--- a/src/Dapper.FSharp/LinqBuilders.fs
+++ b/src/Dapper.FSharp/LinqBuilders.fs
@@ -89,6 +89,10 @@ type SelectExpressionBuilder<'T>() =
     member _.Yield _ =
         QuerySource<'T>(Map.empty)
 
+    // Prevents errors while typing join statement if rest of query is not filled in yet.
+    member this.Zero _ = 
+        QuerySource<'T>(Map.empty)
+
     /// Sets the WHERE condition
     [<CustomOperation("where", MaintainsVariableSpace = true)>]
     member _.Where (state:QuerySource<'T>, [<ProjectionParameter>] whereExpression) = 


### PR DESCRIPTION
This is a small improvement I found last night that prevents the compiler from fighting with you while entering joins when the rest of the query is not completed.