### PR TITLE
Fix ambiguous column error

### DIFF
--- a/src/Dapper.FSharp/MSSQL/GenericDeconstructor.fs
+++ b/src/Dapper.FSharp/MSSQL/GenericDeconstructor.fs
@@ -11,7 +11,7 @@ let private extractFieldsAndSplit<'a> (j:Join) =
 let private createSplitOn (xs:string list) = xs |> String.concat ","
 
 let select1<'a> evalSelectQuery (q:SelectQuery) =
-    let fields = typeof<'a> |> Reflection.getFields
+    let fields = typeof<'a> |> Reflection.getFields |> if q.Joins = [] then id else List.map (sprintf "%s.%s" q.Table)
     // extract metadata
     let meta = WhereAnalyzer.getWhereMetadata [] q.Where
     let joinMeta = JoinAnalyzer.getJoinMetadata q.Joins

--- a/src/Dapper.FSharp/MySQL/GenericDeconstructor.fs
+++ b/src/Dapper.FSharp/MySQL/GenericDeconstructor.fs
@@ -11,7 +11,7 @@ let private extractFieldsAndSplit<'a> (j:Join) =
 let private createSplitOn (xs:string list) = xs |> String.concat ","
 
 let select1<'a> evalSelectQuery (q:SelectQuery) =
-    let fields = typeof<'a> |> Reflection.getFields
+    let fields = typeof<'a> |> Reflection.getFields |> if q.Joins = [] then id else List.map (sprintf "%s.%s" q.Table)
     // extract metadata
     let meta = WhereAnalyzer.getWhereMetadata [] q.Where
     let joinMeta = JoinAnalyzer.getJoinMetadata q.Joins

--- a/src/Dapper.FSharp/PostgreSQL/GenericDeconstructor.fs
+++ b/src/Dapper.FSharp/PostgreSQL/GenericDeconstructor.fs
@@ -14,7 +14,7 @@ let private extractFieldsAndSplit<'a> (j:Join) =
 let private createSplitOn (xs:string list) = xs |> String.concat ","
 
 let select1<'a> evalSelectQuery (q:SelectQuery) =
-    let fields = typeof<'a> |> Reflection.getFields
+    let fields = typeof<'a> |> Reflection.getFields|> if q.Joins = [] then id else List.map (sprintf "%s.%s" q.Table)
     // extract metadata
     let meta = getWhereMetadata [] q.Where
     let joinMeta = getJoinMetadata q.Joins

--- a/src/Dapper.FSharp/SQLite/GenericDeconstructor.fs
+++ b/src/Dapper.FSharp/SQLite/GenericDeconstructor.fs
@@ -11,7 +11,7 @@ let private extractFieldsAndSplit<'a> (j:Join) =
 let private createSplitOn (xs:string list) = xs |> String.concat ","
 
 let select1<'a> evalSelectQuery (q:SelectQuery) =
-    let fields = typeof<'a> |> Reflection.getFields
+    let fields = typeof<'a> |> Reflection.getFields |> if q.Joins = [] then id else List.map (sprintf "%s.%s" q.Table)
     // extract metadata
     let meta = WhereAnalyzer.getWhereMetadata [] q.Where
     let joinMeta = JoinAnalyzer.getJoinMetadata q.Joins

--- a/tests/Dapper.FSharp.Tests/Database.fs
+++ b/tests/Dapper.FSharp.Tests/Database.fs
@@ -73,7 +73,7 @@ module Dogs =
             [1..count]
             |> List.map (fun i ->
                 {
-                    Id = System.Guid.NewGuid()
+                    Id = Guid.NewGuid()
                     OwnerId = owner.Id
                     Nickname = sprintf "Dog_%i" i
                 }

--- a/tests/Dapper.FSharp.Tests/Database.fs
+++ b/tests/Dapper.FSharp.Tests/Database.fs
@@ -53,6 +53,7 @@ module Persons =
 module Dogs =
 
     type View = {
+        Id : Guid
         OwnerId : Guid
         Nickname : string
     }
@@ -62,6 +63,7 @@ module Dogs =
             owners
             |> List.mapi (fun i x ->
                 {
+                    Id = System.Guid.NewGuid()
                     OwnerId = x.Id
                     Nickname = sprintf "Dog_%i" i
                 }
@@ -71,6 +73,7 @@ module Dogs =
             [1..count]
             |> List.map (fun i ->
                 {
+                    Id = System.Guid.NewGuid()
                     OwnerId = owner.Id
                     Nickname = sprintf "Dog_%i" i
                 }

--- a/tests/Dapper.FSharp.Tests/MSSQL/Database.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/Database.fs
@@ -78,6 +78,7 @@ module Dogs =
             do!
                 """
                 CREATE TABLE [dbo].[Dogs](
+                    [Id] [uniqueidentifier] NOT NULL,
                     [OwnerId] [uniqueidentifier] NOT NULL,
                     [Nickname] [nvarchar](max) NOT NULL
                 )

--- a/tests/Dapper.FSharp.Tests/MySQL/Database.fs
+++ b/tests/Dapper.FSharp.Tests/MySQL/Database.fs
@@ -82,6 +82,7 @@ module Dogs =
             do!
                 """
                 CREATE TABLE Dogs (
+                    Id char(36) not null,
                     OwnerId char(36) not null,
                     Nickname longtext not null
                 )

--- a/tests/Dapper.FSharp.Tests/MySQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/MySQL/SelectTests.fs
@@ -449,7 +449,36 @@ type SelectTests () =
             Assert.AreEqual(1, Seq.length byOwner)
             Assert.AreEqual(5, byOwner |> Seq.head |> snd |> Seq.length)
         }
-        
+
+    [<Test>]
+    member _.``Selects with one inner join - 1:N select only one table``() =
+        task {
+            do! init.InitPersons()
+            do! init.InitDogs()
+            let persons = Persons.View.generate 10
+            let dogs = Dogs.View.generate1toN 5 persons.Head
+            let! _ =
+                insert {
+                    into personsView
+                    values persons
+                } |> conn.InsertAsync
+            let! _ =
+                insert {
+                    into dogsView
+                    values dogs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    innerJoin d in dogsView on (p.Id = d.OwnerId)
+                    distinct
+                    selectAll
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual(1, Seq.length fromDb)
+            Assert.AreEqual(persons.Head, (Seq.head fromDb))
+        }
+
     [<Test>]
     member _.``Selects with one left join``() =
         task {

--- a/tests/Dapper.FSharp.Tests/PostgreSQL/Database.fs
+++ b/tests/Dapper.FSharp.Tests/PostgreSQL/Database.fs
@@ -78,6 +78,7 @@ module Dogs =
             do!
                 """
                 create table "Dogs" (
+                    "Id" uuid not null,
                     "OwnerId" uuid not null,
                     "Nickname" text not null
                 )

--- a/tests/Dapper.FSharp.Tests/PostgreSQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/PostgreSQL/SelectTests.fs
@@ -450,7 +450,36 @@ type SelectTests () =
             Assert.AreEqual(1, Seq.length byOwner)
             Assert.AreEqual(5, byOwner |> Seq.head |> snd |> Seq.length)
         }
-        
+
+    [<Test>]
+    member _.``Selects with one inner join - 1:N select only one table``() =
+        task {
+            do! init.InitPersons()
+            do! init.InitDogs()
+            let persons = Persons.View.generate 10
+            let dogs = Dogs.View.generate1toN 5 persons.Head
+            let! _ =
+                insert {
+                    into personsView
+                    values persons
+                } |> conn.InsertAsync
+            let! _ =
+                insert {
+                    into dogsView
+                    values dogs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    innerJoin d in dogsView on (p.Id = d.OwnerId)
+                    distinct
+                    selectAll
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual(1, Seq.length fromDb)
+            Assert.AreEqual(persons.Head, (Seq.head fromDb))
+        }
+
     [<Test>]
     member _.``Selects with one left join``() =
         task {

--- a/tests/Dapper.FSharp.Tests/SQLite/Database.fs
+++ b/tests/Dapper.FSharp.Tests/SQLite/Database.fs
@@ -69,6 +69,7 @@ module Dogs =
             do!
                 """
                 CREATE TABLE [Dogs](
+                    [Id] [TEXT] NOT NULL,
                     [OwnerId] [TEXT] NOT NULL,
                     [Nickname] [TEXT] NOT NULL
                 )

--- a/tests/Dapper.FSharp.Tests/SQLite/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/SQLite/SelectTests.fs
@@ -449,7 +449,36 @@ type SelectTests () =
             Assert.AreEqual(1, Seq.length byOwner)
             Assert.AreEqual(5, byOwner |> Seq.head |> snd |> Seq.length)
         }
-        
+
+    [<Test>]
+    member _.``Selects with one inner join - 1:N select only one table``() =
+        task {
+            do! init.InitPersons()
+            do! init.InitDogs()
+            let persons = Persons.View.generate 10
+            let dogs = Dogs.View.generate1toN 5 persons.Head
+            let! _ =
+                insert {
+                    into personsView
+                    values persons
+                } |> conn.InsertAsync
+            let! _ =
+                insert {
+                    into dogsView
+                    values dogs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    innerJoin d in dogsView on (p.Id = d.OwnerId)
+                    distinct
+                    selectAll
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual(1, Seq.length fromDb)
+            Assert.AreEqual(persons.Head, (Seq.head fromDb))
+        }
+
     [<Test>]
     member _.``Selects with one left join``() =
         task {


### PR DESCRIPTION
"Ambiguous column" error can happen when we try to limit select query with join(s) to just one table. This PR fixes that by fully qualifying column names also for `select1` when there is some join in query.

`Dogs` test table was extended with `Id` column to create ambiguous columns scenario. 