### PR TITLE
Support "if" and pattern match in where condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,25 @@ select {
 } |> conn.SelectAsync<Person>
 ```
 
+You can use `if` expression in `where` condition, but condition must be of type `bool`:
+
+```F#
+select {
+    for p in personTable do
+    where (if usePositionFilter then p.Position > 5 else true)
+} |> conn.SelectAsync<Person>
+```
+
+You can use pattern match expression in `where` condition:
+
+```F#
+select {
+    for p in personTable do
+    where (match positionFilter with | Some x -> p.Position > x | None -> true)
+} |> conn.SelectAsync<Person>
+```
+(Only usage of `Option`, `Result` and simple custom DU was tested, its possible you will encounter some issues with more complex DU)
+
 NOTE: Do not use the forward pipe `|>` operator in your query expressions because it's not implemented, so don't do it (unless you like exceptions)!
 
 To use LIKE operator in `where` condition, use `like`:

--- a/src/Dapper.FSharp/MSSQL/Domain.fs
+++ b/src/Dapper.FSharp/MSSQL/Domain.fs
@@ -34,6 +34,8 @@ type Where =
     | Binary of Where * BinaryOperation * Where
     | Unary of UnaryOperation * Where
     | Expr of string
+    | True
+    | False
     static member (+) (a, b) = Binary(a, And, b)
     static member (*) (a, b) = Binary(a, Or, b)
     static member (!!) a = Unary (Not, a)

--- a/src/Dapper.FSharp/MSSQL/Evaluator.fs
+++ b/src/Dapper.FSharp/MSSQL/Evaluator.fs
@@ -24,6 +24,8 @@ let rec evalWhere (meta:WhereAnalyzer.FieldWhereMetadata list) (w:Where) =
     match w with
     | Empty -> ""
     | Expr expr -> expr
+    | True -> "1=1"
+    | False -> "1=0"
     | Column (field, comp) ->
         let fieldMeta = meta |> List.find (fun x -> x.Key = (field,comp))
         let withField op = sprintf "%s %s @%s" (inBrackets fieldMeta.Name) op fieldMeta.ParameterName

--- a/src/Dapper.FSharp/MSSQL/LinqExpressionVisitors.fs
+++ b/src/Dapper.FSharp/MSSQL/LinqExpressionVisitors.fs
@@ -111,22 +111,12 @@ module SqlPatterns =
         | ExpressionType.LessThanOrEqual -> Some (exp :?> BinaryExpression)
         | _ -> None
 
-    let (|EqualCompare|_|) (exp: Expression) =
-        match exp.NodeType with
-        | ExpressionType.Equal -> Some (exp :?> BinaryExpression)
-        | _ -> None
-
     let (|IfElse|_|) (exp: Expression) =
         match exp.NodeType with
         | ExpressionType.Conditional -> Some (exp :?> ConditionalExpression)
         | _ -> None
 
-    let (|Match|_|) (exp: Expression) =
-        match exp.NodeType with
-        | ExpressionType.Conditional -> Some (exp :?> ConditionalExpression)
-        | _ -> None
-
-    let isOptionType (t: Type) = 
+    let isOptionType (t: Type) =
         t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Option<_>>
 
     /// A property member, a property wrapped in 'Some', or an option 'Value'.
@@ -251,7 +241,6 @@ let getComparisonOp (expType: ExpressionType) =
     | ExpressionType.LessThanOrEqual -> (<=)
     | _ -> notImplMsg "Unsupported comparison type"
 
-
 let rec unwrapListExpr (lstValues: obj list, lstExp: MethodCallExpression) =
     if lstExp.Arguments.Count > 0 then
         match lstExp.Arguments.[0] with
@@ -318,14 +307,6 @@ let visitWhere<'T> (filter: Expression<Func<'T, bool>>) (qualifyColumn: MemberIn
                 let rt = visit x.Right
                 Binary (lt, Or, rt)
         | BinaryCompare x ->
-            match x.Left with
-            | Property p1 -> ()
-            | ValueOrParameterSubstitute sub v -> ()
-            | _ -> ()
-            match x.Right with
-            | Property p1 -> ()
-            | ValueOrParameterSubstitute sub v -> ()
-            | _ -> ()
             match x.Left, x.Right with
             | Property p1, Property p2 ->
                 // Handle col to col comparisons

--- a/src/Dapper.FSharp/MSSQL/WhereAnalyzer.fs
+++ b/src/Dapper.FSharp/MSSQL/WhereAnalyzer.fs
@@ -30,7 +30,9 @@ let normalizeParamName (s:string) = s.Replace(".","_")
 
 let rec getWhereMetadata (meta:FieldWhereMetadata list) (w:Where)  =
     match w with
-    | Empty -> meta
+    | Empty
+    | True
+    | False
     | Expr _ -> meta
     | Column (field, comp) ->
         let parName =

--- a/src/Dapper.FSharp/MySQL/Domain.fs
+++ b/src/Dapper.FSharp/MySQL/Domain.fs
@@ -34,6 +34,8 @@ type Where =
     | Binary of Where * BinaryOperation * Where
     | Unary of UnaryOperation * Where
     | Expr of string
+    | True
+    | False
     static member (+) (a, b) = Binary(a, And, b)
     static member (*) (a, b) = Binary(a, Or, b)
     static member (!!) a = Unary (Not, a)

--- a/src/Dapper.FSharp/MySQL/Evaluator.fs
+++ b/src/Dapper.FSharp/MySQL/Evaluator.fs
@@ -26,6 +26,8 @@ let evalOrderDirection = function
 let rec evalWhere (meta:WhereAnalyzer.FieldWhereMetadata list) (w:Where) =
     match w with
     | Empty -> ""
+    | True -> "TRUE"
+    | False -> "FALSE"
     | Expr expr -> expr
     | Column (field, comp) ->
         let fieldMeta = meta |> List.find (fun x -> x.Key = (field,comp))

--- a/src/Dapper.FSharp/MySQL/LinqExpressionVisitors.fs
+++ b/src/Dapper.FSharp/MySQL/LinqExpressionVisitors.fs
@@ -58,7 +58,7 @@ module VisitorPatterns =
 
     let (|MethodCall|_|) (exp: Expression) =
         match exp.NodeType with
-        | ExpressionType.Call -> Some (exp :?> MethodCallExpression)    
+        | ExpressionType.Call -> Some (exp :?> MethodCallExpression)
         | _ -> None
 
     let (|New|_|) (exp: Expression) =
@@ -82,9 +82,9 @@ module VisitorPatterns =
         | _ -> None
 
 [<AutoOpen>]
-module SqlPatterns = 
+module SqlPatterns =
 
-    let (|Not|_|) (exp: Expression) = 
+    let (|Not|_|) (exp: Expression) =
         match exp.NodeType with
         | ExpressionType.Not -> Some (exp :?> UnaryExpression)
         | _ -> None
@@ -111,16 +111,21 @@ module SqlPatterns =
         | ExpressionType.LessThanOrEqual -> Some (exp :?> BinaryExpression)
         | _ -> None
 
-    let isOptionType (t: Type) = 
+    let (|IfElse|_|) (exp: Expression) =
+        match exp.NodeType with
+        | ExpressionType.Conditional -> Some (exp :?> ConditionalExpression)
+        | _ -> None
+
+    let isOptionType (t: Type) =
         t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Option<_>>
 
     /// A property member, a property wrapped in 'Some', or an option 'Value'.
     let (|Property|_|) (exp: Expression) =
-        let tryGetMember(x: Expression) = 
+        let tryGetMember(x: Expression) =
             match x with
-            | Member m when m.Expression.NodeType = ExpressionType.Parameter -> 
+            | Member m when m.Expression.NodeType = ExpressionType.Parameter ->
                 Some m.Member
-            | MethodCall opt when opt.Type |> isOptionType ->        
+            | MethodCall opt when opt.Type |> isOptionType ->
                 if opt.Arguments.Count > 0 then
                     // Option.Some
                     match opt.Arguments.[0] with
@@ -130,32 +135,48 @@ module SqlPatterns =
             | _ -> None
 
         match exp with
-        | Member m when m.Member.DeclaringType <> null && m.Member.DeclaringType |> isOptionType -> 
+        | Member m when m.Member.DeclaringType <> null && m.Member.DeclaringType |> isOptionType ->
             // Handles option '.Value'
             tryGetMember m.Expression
-        | _ -> 
+        | _ ->
             tryGetMember exp
 
     /// A constant value or an optional constant value
     let (|Value|_|) (exp: Expression) =
         match exp with
-        | New n when n.Type.Name = "Guid" -> 
+        | New n when n.Type.Name = "Guid" ->
             let value = (n.Arguments.[0] :?> ConstantExpression).Value :?> string
             Some (Guid(value) |> box)
-        | Member m when m.Expression.NodeType = ExpressionType.Constant -> 
+        | Member m when m.Expression.NodeType = ExpressionType.Constant ->
             // Extract constant value from property (probably a record property)
-            // NOTE: This currently does not unwind nested properties! 
+            // NOTE: This currently does not unwind nested properties!
             // NOTE: This uses reflection; it is more performant for user to manually unwrap and pass in constant.
             let parentObject = (m.Expression :?> ConstantExpression).Value
             match m.Member.MemberType with
             | MemberTypes.Field -> (m.Member :?> FieldInfo).GetValue(parentObject) |> Some
             | MemberTypes.Property -> (m.Member :?> PropertyInfo).GetValue(parentObject) |> Some
             | _ -> notImplMsg(sprintf "Unable to unwrap where value for '%s'" m.Member.Name)
-        | Member m when m.Expression.NodeType = ExpressionType.MemberAccess -> 
+        // Get value from DU case
+        | Member m when m.Expression.NodeType = ExpressionType.TypeAs ->
+            match (m.Expression :?> UnaryExpression).Operand with
+            | Constant c when Reflection.FSharpType.IsUnion c.Type ->
+                let values = Reflection.FSharpValue.GetUnionFields(c.Value, c.Type) |> snd
+                match m.Member.Name with
+                | "Item"
+                | "Item1" -> Some values.[0]
+                | "Item2" -> Some values.[1]
+                | "Item3" -> Some values.[2]
+                | "Item4" -> Some values.[3]
+                | "Item5" -> Some values.[4]
+                | "Item6" -> Some values.[5]
+                | "Item7" -> Some values.[6]
+                | _ -> None
+            | _ -> None
+        | Member m when m.Expression.NodeType = ExpressionType.MemberAccess ->
             // Extract constant value from nested object/properties
             notImplMsg "Nested property value extraction is not supported in 'where' statements. Try manually unwrapping and passing in the value."
         | Constant c -> Some c.Value
-        | MethodCall opt when opt.Type |> isOptionType ->        
+        | MethodCall opt when opt.Type |> isOptionType ->
             if opt.Arguments.Count > 0 then
                 // Option.Some
                 match opt.Arguments.[0] with
@@ -164,6 +185,28 @@ module SqlPatterns =
             else
                 // Option.None
                 Some null
+        | _ -> None
+
+    let (|ValueOrParameterSubstitute|_|) (sub: Map<string, Expression>) (exp: Expression) =
+        match exp with
+        | Value x -> Some x
+        | Parameter p ->
+            match sub |> Map.tryFind p.Name with
+            | Some (Value v) -> Some v
+            | _ -> None
+        | _ -> None
+
+    let (|GetTagCondition|_|) (exp: Expression) =
+        match exp.NodeType with
+        | ExpressionType.Equal ->
+            let b = exp :?> BinaryExpression
+            match b.Left with
+            | MethodCall m when m.Method.Name = "GetTag" ->
+                match m.Arguments[0], b.Right with
+                | Constant c, Constant right ->
+                    if (m.Method.Invoke(null, [| c.Value |]) :?> int) = (right.Value :?> int) then Some true else Some false
+                | _ -> None
+            | _ -> None
         | _ -> None
 
 let getColumnComparison (expType: ExpressionType, value: obj) =
@@ -188,37 +231,55 @@ let getComparison (expType: ExpressionType) =
     | ExpressionType.LessThanOrEqual -> "<="
     | _ -> notImplMsg "Unsupported comparison type"
 
+let getComparisonOp (expType: ExpressionType) =
+    match expType with
+    | ExpressionType.Equal -> (=)
+    | ExpressionType.NotEqual -> (<>)
+    | ExpressionType.GreaterThan -> (>)
+    | ExpressionType.GreaterThanOrEqual -> (>=)
+    | ExpressionType.LessThan -> (<)
+    | ExpressionType.LessThanOrEqual -> (<=)
+    | _ -> notImplMsg "Unsupported comparison type"
+
 let rec unwrapListExpr (lstValues: obj list, lstExp: MethodCallExpression) =
     if lstExp.Arguments.Count > 0 then
         match lstExp.Arguments.[0] with
         | Constant c -> unwrapListExpr (lstValues @ [c.Value], (lstExp.Arguments.[1] :?> MethodCallExpression))
         | _ -> notImpl()
-    else 
+    else
         lstValues
 
 let visitWhere<'T> (filter: Expression<Func<'T, bool>>) (qualifyColumn: MemberInfo -> string) =
-    let rec visit (exp: Expression) : Where =
+    let rec visitSubParam (sub: Map<string, Expression>) (exp: Expression) : Where =
+        let visit = visitSubParam sub
         match exp with
+        | Constant c when c.Value = true ->
+            True
+        | Constant c when c.Value = false ->
+            False
         | Lambda x -> visit x.Body
-        | Not x -> 
+        | Not x ->
             let operand = visit x.Operand
             Unary (Not, operand)
         | MethodCall m when m.Method.Name = "Invoke" ->
+            match Seq.tryHead m.Arguments, m.Object with
+            | Some x, Lambda l -> visitSubParam (sub |> Map.add l.Parameters[0].Name x) m.Object
+            | _ ->
             // Handle tuples
             visit m.Object
         | MethodCall m when List.contains m.Method.Name [ "isIn"; "isNotIn" ] ->
             let comparisonType = m.Method.Name |> function "isIn" -> In | _ -> NotIn
             match m.Arguments.[0], m.Arguments.[1] with
             | Property p, MethodCall lst ->
-                let lstValues = unwrapListExpr ([], lst)                
+                let lstValues = unwrapListExpr ([], lst)
                 Column (qualifyColumn p, comparisonType lstValues)
-            | Property p, Value value -> 
+            | Property p, Value value ->
                 let lstValues = (value :?> System.Collections.IEnumerable) |> Seq.cast<obj> |> Seq.toList
                 Column (qualifyColumn p, comparisonType lstValues)
             | _ -> notImpl()
         | MethodCall m when List.contains m.Method.Name [ "like"; "notLike" ] ->
             match m.Arguments.[0], m.Arguments.[1] with
-            | Property p, Value value -> 
+            | Property p, ValueOrParameterSubstitute sub value ->
                 let pattern = string value
                 match m.Method.Name with
                 | "like" -> Column ((qualifyColumn p), (Like pattern))
@@ -226,42 +287,58 @@ let visitWhere<'T> (filter: Expression<Func<'T, bool>>) (qualifyColumn: MemberIn
             | _ -> notImpl()
         | MethodCall m when m.Method.Name = "isNullValue" || m.Method.Name = "isNotNullValue" ->
             match m.Arguments.[0] with
-            | Property p -> 
-                if m.Method.Name = "isNullValue" 
+            | Property p ->
+                if m.Method.Name = "isNullValue"
                 then Column (qualifyColumn p, ColumnComparison.IsNull)
                 else Column (qualifyColumn p, ColumnComparison.IsNotNull)
             | _ -> notImpl()
+        // support pattern match
+        | GetTagCondition b -> if b then True else False
         | BinaryAnd x ->
-            let lt = visit x.Left
-            let rt = visit x.Right
-            Binary (lt, And, rt)
-        | BinaryOr x -> 
-            let lt = visit x.Left
-            let rt = visit x.Right
-            Binary (lt, Or, rt)
+            match visit x.Left with
+            | False -> False // short circuit, because `if c then x else false` is converted to c && x
+            | lt ->
+                let rt = visit x.Right
+                Binary (lt, And, rt)
+        | BinaryOr x ->
+            match visit x.Left with
+            | True -> True // short circuit, because `if c then true else x` is converted to c || x
+            | lt ->
+                let rt = visit x.Right
+                Binary (lt, Or, rt)
         | BinaryCompare x ->
-            match x.Left, x.Right with            
+            match x.Left, x.Right with
             | Property p1, Property p2 ->
                 // Handle col to col comparisons
                 let lt = qualifyColumn p1
                 let cp = getComparison exp.NodeType
                 let rt = qualifyColumn p2
                 Expr (sprintf "%s %s %s" lt cp rt)
-            | Property p, Value value
-            | Value value, Property p ->
+            | Property p, ValueOrParameterSubstitute sub value
+            | ValueOrParameterSubstitute sub value, Property p ->
                 // Handle column to value comparisons
                 let columnComparison = getColumnComparison(exp.NodeType, value)
                 Column (qualifyColumn p, columnComparison)
-            | Value v1, Value v2 ->
+            | ValueOrParameterSubstitute sub v1, ValueOrParameterSubstitute sub v2 when (v1 :? int) && (v2 :? int) -> if (getComparisonOp exp.NodeType) (v1 :?> int) (v2 :?> int) then True else False
+            | ValueOrParameterSubstitute sub v1, ValueOrParameterSubstitute sub v2 when (v1 :? bool) && (v2 :? bool) -> if (getComparisonOp exp.NodeType) (v1 :?> bool) (v2 :?> bool) then True else False
+            | ValueOrParameterSubstitute sub v1, ValueOrParameterSubstitute sub v2 ->
                 // Not implemented because I didn't want to embed logic to properly format strings, dates, etc.
                 // This can be easily added later if it is implemented in Dapper.FSharp.
-                notImplMsg("Value to value comparisons are not currently supported. Ex: where (1 = 1)")
+                notImplMsg("Value to value comparisons are currently supported only for int and bool. Ex: where (1 = 1)")
             | _ ->
                 notImpl()
+        | IfElse x ->
+            match visit x.Test with
+            | True ->
+                visit x.IfTrue
+            | False ->
+                visit x.IfFalse
+            | _ -> notImplMsg "Only boolean constant as condition is supported."
+
         | _ ->
             notImpl()
 
-    visit (filter :> Expression)
+    visitSubParam Map.empty (filter :> Expression)
 
 /// Returns a list of one or more fully qualified column names: ["{schema}.{table}.{column}"]
 let visitGroupBy<'T, 'Prop> (propertySelector: Expression<Func<'T, 'Prop>>) (qualifyColumn: MemberInfo -> string) =

--- a/src/Dapper.FSharp/MySQL/WhereAnalyzer.fs
+++ b/src/Dapper.FSharp/MySQL/WhereAnalyzer.fs
@@ -30,7 +30,9 @@ let normalizeParamName (s:string) = s.Replace(".","_")
 
 let rec getWhereMetadata (meta:FieldWhereMetadata list) (w:Where)  =
     match w with
-    | Empty -> meta
+    | Empty
+    | True
+    | False
     | Expr _ -> meta
     | Column (field, comp) ->
         let parName =

--- a/src/Dapper.FSharp/PostgreSQL/Domain.fs
+++ b/src/Dapper.FSharp/PostgreSQL/Domain.fs
@@ -36,6 +36,8 @@ type Where =
     | Binary of Where * BinaryOperation * Where
     | Unary of UnaryOperation * Where
     | Expr of string
+    | True
+    | False
     static member (+) (a, b) = Binary(a, And, b)
     static member (*) (a, b) = Binary(a, Or, b)
     static member (!!) a = Unary (Not, a)

--- a/src/Dapper.FSharp/PostgreSQL/Evaluator.fs
+++ b/src/Dapper.FSharp/PostgreSQL/Evaluator.fs
@@ -30,6 +30,8 @@ let evalOrderDirection = function
 let rec evalWhere (meta:FieldWhereMetadata list) (w:Where) =
     match w with
     | Empty -> ""
+    | True -> "TRUE"
+    | False -> "FALSE"
     | Expr expr -> expr
     | Column (field, comp) ->
         let fieldMeta = meta |> List.find (fun x -> x.Key = (field,comp))

--- a/src/Dapper.FSharp/PostgreSQL/LinqExpressionVisitors.fs
+++ b/src/Dapper.FSharp/PostgreSQL/LinqExpressionVisitors.fs
@@ -59,7 +59,7 @@ module VisitorPatterns =
 
     let (|MethodCall|_|) (exp: Expression) =
         match exp.NodeType with
-        | ExpressionType.Call -> Some (exp :?> MethodCallExpression)    
+        | ExpressionType.Call -> Some (exp :?> MethodCallExpression)
         | _ -> None
 
     let (|New|_|) (exp: Expression) =
@@ -83,9 +83,9 @@ module VisitorPatterns =
         | _ -> None
 
 [<AutoOpen>]
-module SqlPatterns = 
+module SqlPatterns =
 
-    let (|Not|_|) (exp: Expression) = 
+    let (|Not|_|) (exp: Expression) =
         match exp.NodeType with
         | ExpressionType.Not -> Some (exp :?> UnaryExpression)
         | _ -> None
@@ -112,16 +112,21 @@ module SqlPatterns =
         | ExpressionType.LessThanOrEqual -> Some (exp :?> BinaryExpression)
         | _ -> None
 
-    let isOptionType (t: Type) = 
+    let (|IfElse|_|) (exp: Expression) =
+        match exp.NodeType with
+        | ExpressionType.Conditional -> Some (exp :?> ConditionalExpression)
+        | _ -> None
+
+    let isOptionType (t: Type) =
         t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Option<_>>
 
     /// A property member, a property wrapped in 'Some', or an option 'Value'.
     let (|Property|_|) (exp: Expression) =
-        let tryGetMember(x: Expression) = 
+        let tryGetMember(x: Expression) =
             match x with
-            | Member m when m.Expression.NodeType = ExpressionType.Parameter -> 
+            | Member m when m.Expression.NodeType = ExpressionType.Parameter ->
                 Some m.Member
-            | MethodCall opt when opt.Type |> isOptionType ->        
+            | MethodCall opt when opt.Type |> isOptionType ->
                 if opt.Arguments.Count > 0 then
                     // Option.Some
                     match opt.Arguments.[0] with
@@ -131,32 +136,48 @@ module SqlPatterns =
             | _ -> None
 
         match exp with
-        | Member m when m.Member.DeclaringType <> null && m.Member.DeclaringType |> isOptionType -> 
+        | Member m when m.Member.DeclaringType <> null && m.Member.DeclaringType |> isOptionType ->
             // Handles option '.Value'
             tryGetMember m.Expression
-        | _ -> 
+        | _ ->
             tryGetMember exp
 
     /// A constant value or an optional constant value
     let (|Value|_|) (exp: Expression) =
         match exp with
-        | New n when n.Type.Name = "Guid" -> 
+        | New n when n.Type.Name = "Guid" ->
             let value = (n.Arguments.[0] :?> ConstantExpression).Value :?> string
             Some (Guid(value) |> box)
-        | Member m when m.Expression.NodeType = ExpressionType.Constant -> 
+        | Member m when m.Expression.NodeType = ExpressionType.Constant ->
             // Extract constant value from property (probably a record property)
-            // NOTE: This currently does not unwind nested properties! 
+            // NOTE: This currently does not unwind nested properties!
             // NOTE: This uses reflection; it is more performant for user to manually unwrap and pass in constant.
             let parentObject = (m.Expression :?> ConstantExpression).Value
             match m.Member.MemberType with
             | MemberTypes.Field -> (m.Member :?> FieldInfo).GetValue(parentObject) |> Some
             | MemberTypes.Property -> (m.Member :?> PropertyInfo).GetValue(parentObject) |> Some
             | _ -> notImplMsg(sprintf "Unable to unwrap where value for '%s'" m.Member.Name)
-        | Member m when m.Expression.NodeType = ExpressionType.MemberAccess -> 
+        // Get value from DU case
+        | Member m when m.Expression.NodeType = ExpressionType.TypeAs ->
+            match (m.Expression :?> UnaryExpression).Operand with
+            | Constant c when Reflection.FSharpType.IsUnion c.Type ->
+                let values = Reflection.FSharpValue.GetUnionFields(c.Value, c.Type) |> snd
+                match m.Member.Name with
+                | "Item"
+                | "Item1" -> Some values.[0]
+                | "Item2" -> Some values.[1]
+                | "Item3" -> Some values.[2]
+                | "Item4" -> Some values.[3]
+                | "Item5" -> Some values.[4]
+                | "Item6" -> Some values.[5]
+                | "Item7" -> Some values.[6]
+                | _ -> None
+            | _ -> None
+        | Member m when m.Expression.NodeType = ExpressionType.MemberAccess ->
             // Extract constant value from nested object/properties
             notImplMsg "Nested property value extraction is not supported in 'where' statements. Try manually unwrapping and passing in the value."
         | Constant c -> Some c.Value
-        | MethodCall opt when opt.Type |> isOptionType ->        
+        | MethodCall opt when opt.Type |> isOptionType ->
             if opt.Arguments.Count > 0 then
                 // Option.Some
                 match opt.Arguments.[0] with
@@ -165,6 +186,28 @@ module SqlPatterns =
             else
                 // Option.None
                 Some null
+        | _ -> None
+
+    let (|ValueOrParameterSubstitute|_|) (sub: Map<string, Expression>) (exp: Expression) =
+        match exp with
+        | Value x -> Some x
+        | Parameter p ->
+            match sub |> Map.tryFind p.Name with
+            | Some (Value v) -> Some v
+            | _ -> None
+        | _ -> None
+
+    let (|GetTagCondition|_|) (exp: Expression) =
+        match exp.NodeType with
+        | ExpressionType.Equal ->
+            let b = exp :?> BinaryExpression
+            match b.Left with
+            | MethodCall m when m.Method.Name = "GetTag" ->
+                match m.Arguments[0], b.Right with
+                | Constant c, Constant right ->
+                    if (m.Method.Invoke(null, [| c.Value |]) :?> int) = (right.Value :?> int) then Some true else Some false
+                | _ -> None
+            | _ -> None
         | _ -> None
 
 let getColumnComparison (expType: ExpressionType, value: obj) =
@@ -189,37 +232,55 @@ let getComparison (expType: ExpressionType) =
     | ExpressionType.LessThanOrEqual -> "<="
     | _ -> notImplMsg "Unsupported comparison type"
 
+let getComparisonOp (expType: ExpressionType) =
+    match expType with
+    | ExpressionType.Equal -> (=)
+    | ExpressionType.NotEqual -> (<>)
+    | ExpressionType.GreaterThan -> (>)
+    | ExpressionType.GreaterThanOrEqual -> (>=)
+    | ExpressionType.LessThan -> (<)
+    | ExpressionType.LessThanOrEqual -> (<=)
+    | _ -> notImplMsg "Unsupported comparison type"
+
 let rec unwrapListExpr (lstValues: obj list, lstExp: MethodCallExpression) =
     if lstExp.Arguments.Count > 0 then
         match lstExp.Arguments.[0] with
         | Constant c -> unwrapListExpr (lstValues @ [c.Value], (lstExp.Arguments.[1] :?> MethodCallExpression))
         | _ -> notImpl()
-    else 
+    else
         lstValues
 
 let visitWhere<'T> (filter: Expression<Func<'T, bool>>) (qualifyColumn: MemberInfo -> string) =
-    let rec visit (exp: Expression) : Where =
+    let rec visitSubParam (sub: Map<string, Expression>) (exp: Expression) : Where =
+        let visit = visitSubParam sub
         match exp with
+        | Constant c when c.Value = true ->
+            True
+        | Constant c when c.Value = false ->
+            False
         | Lambda x -> visit x.Body
-        | Not x -> 
+        | Not x ->
             let operand = visit x.Operand
             Unary (Not, operand)
         | MethodCall m when m.Method.Name = "Invoke" ->
+            match Seq.tryHead m.Arguments, m.Object with
+            | Some x, Lambda l -> visitSubParam (sub |> Map.add l.Parameters[0].Name x) m.Object
+            | _ ->
             // Handle tuples
             visit m.Object
         | MethodCall m when List.contains m.Method.Name [ "isIn"; "isNotIn" ] ->
             let comparisonType = m.Method.Name |> function "isIn" -> In | _ -> NotIn
             match m.Arguments.[0], m.Arguments.[1] with
             | Property p, MethodCall lst ->
-                let lstValues = unwrapListExpr ([], lst)                
+                let lstValues = unwrapListExpr ([], lst)
                 Column (qualifyColumn p, comparisonType lstValues)
-            | Property p, Value value -> 
+            | Property p, Value value ->
                 let lstValues = (value :?> System.Collections.IEnumerable) |> Seq.cast<obj> |> Seq.toList
                 Column (qualifyColumn p, comparisonType lstValues)
             | _ -> notImpl()
         | MethodCall m when List.contains m.Method.Name [ "like"; "notLike"; "ilike"; "notILike" ] ->
             match m.Arguments.[0], m.Arguments.[1] with
-            | Property p, Value value -> 
+            | Property p, ValueOrParameterSubstitute sub value ->
                 let pattern = string value
                 match m.Method.Name with
                 | "like" -> Column ((qualifyColumn p), (Like pattern))
@@ -230,42 +291,58 @@ let visitWhere<'T> (filter: Expression<Func<'T, bool>>) (qualifyColumn: MemberIn
             | _ -> notImpl()
         | MethodCall m when m.Method.Name = "isNullValue" || m.Method.Name = "isNotNullValue" ->
             match m.Arguments.[0] with
-            | Property p -> 
-                if m.Method.Name = "isNullValue" 
+            | Property p ->
+                if m.Method.Name = "isNullValue"
                 then Column (qualifyColumn p, ColumnComparison.IsNull)
                 else Column (qualifyColumn p, ColumnComparison.IsNotNull)
             | _ -> notImpl()
+        // support pattern match
+        | GetTagCondition b -> if b then True else False
         | BinaryAnd x ->
-            let lt = visit x.Left
-            let rt = visit x.Right
-            Binary (lt, And, rt)
-        | BinaryOr x -> 
-            let lt = visit x.Left
-            let rt = visit x.Right
-            Binary (lt, Or, rt)
+            match visit x.Left with
+            | False -> False // short circuit, because `if c then x else false` is converted to c && x
+            | lt ->
+                let rt = visit x.Right
+                Binary (lt, And, rt)
+        | BinaryOr x ->
+            match visit x.Left with
+            | True -> True // short circuit, because `if c then true else x` is converted to c || x
+            | lt ->
+                let rt = visit x.Right
+                Binary (lt, Or, rt)
         | BinaryCompare x ->
-            match x.Left, x.Right with            
+            match x.Left, x.Right with
             | Property p1, Property p2 ->
                 // Handle col to col comparisons
                 let lt = qualifyColumn p1
                 let cp = getComparison exp.NodeType
                 let rt = qualifyColumn p2
                 Expr (sprintf "%s %s %s" lt cp rt)
-            | Property p, Value value
-            | Value value, Property p ->
+            | Property p, ValueOrParameterSubstitute sub value
+            | ValueOrParameterSubstitute sub value, Property p ->
                 // Handle column to value comparisons
                 let columnComparison = getColumnComparison(exp.NodeType, value)
                 Column (qualifyColumn p, columnComparison)
-            | Value v1, Value v2 ->
+            | ValueOrParameterSubstitute sub v1, ValueOrParameterSubstitute sub v2 when (v1 :? int) && (v2 :? int) -> if (getComparisonOp exp.NodeType) (v1 :?> int) (v2 :?> int) then True else False
+            | ValueOrParameterSubstitute sub v1, ValueOrParameterSubstitute sub v2 when (v1 :? bool) && (v2 :? bool) -> if (getComparisonOp exp.NodeType) (v1 :?> bool) (v2 :?> bool) then True else False
+            | ValueOrParameterSubstitute sub v1, ValueOrParameterSubstitute sub v2 ->
                 // Not implemented because I didn't want to embed logic to properly format strings, dates, etc.
                 // This can be easily added later if it is implemented in Dapper.FSharp.
-                notImplMsg("Value to value comparisons are not currently supported. Ex: where (1 = 1)")
+                notImplMsg("Value to value comparisons are currently supported only for int and bool. Ex: where (1 = 1)")
             | _ ->
                 notImpl()
+        | IfElse x ->
+            match visit x.Test with
+            | True ->
+                visit x.IfTrue
+            | False ->
+                visit x.IfFalse
+            | _ -> notImplMsg "Only boolean constant as condition is supported."
+
         | _ ->
             notImpl()
 
-    visit (filter :> Expression)
+    visitSubParam Map.empty (filter :> Expression)
 
 /// Returns a list of one or more fully qualified column names: ["{schema}.{table}.{column}"]
 let visitGroupBy<'T, 'Prop> (propertySelector: Expression<Func<'T, 'Prop>>) (qualifyColumn: MemberInfo -> string) =

--- a/src/Dapper.FSharp/PostgreSQL/WhereAnalyzer.fs
+++ b/src/Dapper.FSharp/PostgreSQL/WhereAnalyzer.fs
@@ -33,7 +33,9 @@ let normalizeParamName (s:string) = s.Replace(".","_")
 
 let rec getWhereMetadata (meta:FieldWhereMetadata list) (w:Where)  =
     match w with
-    | Empty -> meta
+    | Empty
+    | True
+    | False
     | Expr _ -> meta
     | Column (field, comp) ->
         let parName =

--- a/src/Dapper.FSharp/SQLite/Domain.fs
+++ b/src/Dapper.FSharp/SQLite/Domain.fs
@@ -34,6 +34,8 @@ type Where =
     | Binary of Where * BinaryOperation * Where
     | Unary of UnaryOperation * Where
     | Expr of string
+    | True
+    | False
     static member (+) (a, b) = Binary(a, And, b)
     static member (*) (a, b) = Binary(a, Or, b)
     static member (!!) a = Unary (Not, a)

--- a/src/Dapper.FSharp/SQLite/Evaluator.fs
+++ b/src/Dapper.FSharp/SQLite/Evaluator.fs
@@ -21,6 +21,8 @@ let evalOrderDirection = function
 let rec evalWhere (meta:WhereAnalyzer.FieldWhereMetadata list) (w:Where) =
     match w with
     | Empty -> ""
+    | True -> "TRUE"
+    | False -> "FALSE"
     | Expr expr -> expr
     | Column (field, comp) ->
         let fieldMeta = meta |> List.find (fun x -> x.Key = (field,comp))

--- a/src/Dapper.FSharp/SQLite/LinqExpressionVisitors.fs
+++ b/src/Dapper.FSharp/SQLite/LinqExpressionVisitors.fs
@@ -58,7 +58,7 @@ module VisitorPatterns =
 
     let (|MethodCall|_|) (exp: Expression) =
         match exp.NodeType with
-        | ExpressionType.Call -> Some (exp :?> MethodCallExpression)    
+        | ExpressionType.Call -> Some (exp :?> MethodCallExpression)
         | _ -> None
 
     let (|New|_|) (exp: Expression) =
@@ -82,9 +82,9 @@ module VisitorPatterns =
         | _ -> None
 
 [<AutoOpen>]
-module SqlPatterns = 
+module SqlPatterns =
 
-    let (|Not|_|) (exp: Expression) = 
+    let (|Not|_|) (exp: Expression) =
         match exp.NodeType with
         | ExpressionType.Not -> Some (exp :?> UnaryExpression)
         | _ -> None
@@ -111,16 +111,21 @@ module SqlPatterns =
         | ExpressionType.LessThanOrEqual -> Some (exp :?> BinaryExpression)
         | _ -> None
 
-    let isOptionType (t: Type) = 
+    let (|IfElse|_|) (exp: Expression) =
+        match exp.NodeType with
+        | ExpressionType.Conditional -> Some (exp :?> ConditionalExpression)
+        | _ -> None
+
+    let isOptionType (t: Type) =
         t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Option<_>>
 
     /// A property member, a property wrapped in 'Some', or an option 'Value'.
     let (|Property|_|) (exp: Expression) =
-        let tryGetMember(x: Expression) = 
+        let tryGetMember(x: Expression) =
             match x with
-            | Member m when m.Expression.NodeType = ExpressionType.Parameter -> 
+            | Member m when m.Expression.NodeType = ExpressionType.Parameter ->
                 Some m.Member
-            | MethodCall opt when opt.Type |> isOptionType ->        
+            | MethodCall opt when opt.Type |> isOptionType ->
                 if opt.Arguments.Count > 0 then
                     // Option.Some
                     match opt.Arguments.[0] with
@@ -130,32 +135,48 @@ module SqlPatterns =
             | _ -> None
 
         match exp with
-        | Member m when m.Member.DeclaringType <> null && m.Member.DeclaringType |> isOptionType -> 
+        | Member m when m.Member.DeclaringType <> null && m.Member.DeclaringType |> isOptionType ->
             // Handles option '.Value'
             tryGetMember m.Expression
-        | _ -> 
+        | _ ->
             tryGetMember exp
 
     /// A constant value or an optional constant value
     let (|Value|_|) (exp: Expression) =
         match exp with
-        | New n when n.Type.Name = "Guid" -> 
+        | New n when n.Type.Name = "Guid" ->
             let value = (n.Arguments.[0] :?> ConstantExpression).Value :?> string
             Some (Guid(value) |> box)
-        | Member m when m.Expression.NodeType = ExpressionType.Constant -> 
+        | Member m when m.Expression.NodeType = ExpressionType.Constant ->
             // Extract constant value from property (probably a record property)
-            // NOTE: This currently does not unwind nested properties! 
+            // NOTE: This currently does not unwind nested properties!
             // NOTE: This uses reflection; it is more performant for user to manually unwrap and pass in constant.
             let parentObject = (m.Expression :?> ConstantExpression).Value
             match m.Member.MemberType with
             | MemberTypes.Field -> (m.Member :?> FieldInfo).GetValue(parentObject) |> Some
             | MemberTypes.Property -> (m.Member :?> PropertyInfo).GetValue(parentObject) |> Some
             | _ -> notImplMsg(sprintf "Unable to unwrap where value for '%s'" m.Member.Name)
-        | Member m when m.Expression.NodeType = ExpressionType.MemberAccess -> 
+        // Get value from DU case
+        | Member m when m.Expression.NodeType = ExpressionType.TypeAs ->
+            match (m.Expression :?> UnaryExpression).Operand with
+            | Constant c when Reflection.FSharpType.IsUnion c.Type ->
+                let values = Reflection.FSharpValue.GetUnionFields(c.Value, c.Type) |> snd
+                match m.Member.Name with
+                | "Item"
+                | "Item1" -> Some values.[0]
+                | "Item2" -> Some values.[1]
+                | "Item3" -> Some values.[2]
+                | "Item4" -> Some values.[3]
+                | "Item5" -> Some values.[4]
+                | "Item6" -> Some values.[5]
+                | "Item7" -> Some values.[6]
+                | _ -> None
+            | _ -> None
+        | Member m when m.Expression.NodeType = ExpressionType.MemberAccess ->
             // Extract constant value from nested object/properties
             notImplMsg "Nested property value extraction is not supported in 'where' statements. Try manually unwrapping and passing in the value."
         | Constant c -> Some c.Value
-        | MethodCall opt when opt.Type |> isOptionType ->        
+        | MethodCall opt when opt.Type |> isOptionType ->
             if opt.Arguments.Count > 0 then
                 // Option.Some
                 match opt.Arguments.[0] with
@@ -164,6 +185,28 @@ module SqlPatterns =
             else
                 // Option.None
                 Some null
+        | _ -> None
+
+    let (|ValueOrParameterSubstitute|_|) (sub: Map<string, Expression>) (exp: Expression) =
+        match exp with
+        | Value x -> Some x
+        | Parameter p ->
+            match sub |> Map.tryFind p.Name with
+            | Some (Value v) -> Some v
+            | _ -> None
+        | _ -> None
+
+    let (|GetTagCondition|_|) (exp: Expression) =
+        match exp.NodeType with
+        | ExpressionType.Equal ->
+            let b = exp :?> BinaryExpression
+            match b.Left with
+            | MethodCall m when m.Method.Name = "GetTag" ->
+                match m.Arguments[0], b.Right with
+                | Constant c, Constant right ->
+                    if (m.Method.Invoke(null, [| c.Value |]) :?> int) = (right.Value :?> int) then Some true else Some false
+                | _ -> None
+            | _ -> None
         | _ -> None
 
 let getColumnComparison (expType: ExpressionType, value: obj) =
@@ -188,37 +231,55 @@ let getComparison (expType: ExpressionType) =
     | ExpressionType.LessThanOrEqual -> "<="
     | _ -> notImplMsg "Unsupported comparison type"
 
+let getComparisonOp (expType: ExpressionType) =
+    match expType with
+    | ExpressionType.Equal -> (=)
+    | ExpressionType.NotEqual -> (<>)
+    | ExpressionType.GreaterThan -> (>)
+    | ExpressionType.GreaterThanOrEqual -> (>=)
+    | ExpressionType.LessThan -> (<)
+    | ExpressionType.LessThanOrEqual -> (<=)
+    | _ -> notImplMsg "Unsupported comparison type"
+
 let rec unwrapListExpr (lstValues: obj list, lstExp: MethodCallExpression) =
     if lstExp.Arguments.Count > 0 then
         match lstExp.Arguments.[0] with
         | Constant c -> unwrapListExpr (lstValues @ [c.Value], (lstExp.Arguments.[1] :?> MethodCallExpression))
         | _ -> notImpl()
-    else 
+    else
         lstValues
 
 let visitWhere<'T> (filter: Expression<Func<'T, bool>>) (qualifyColumn: MemberInfo -> string) =
-    let rec visit (exp: Expression) : Where =
+    let rec visitSubParam (sub: Map<string, Expression>) (exp: Expression) : Where =
+        let visit = visitSubParam sub
         match exp with
+        | Constant c when c.Value = true ->
+            True
+        | Constant c when c.Value = false ->
+            False
         | Lambda x -> visit x.Body
-        | Not x -> 
+        | Not x ->
             let operand = visit x.Operand
             Unary (Not, operand)
         | MethodCall m when m.Method.Name = "Invoke" ->
+            match Seq.tryHead m.Arguments, m.Object with
+            | Some x, Lambda l -> visitSubParam (sub |> Map.add l.Parameters[0].Name x) m.Object
+            | _ ->
             // Handle tuples
             visit m.Object
         | MethodCall m when List.contains m.Method.Name [ "isIn"; "isNotIn" ] ->
             let comparisonType = m.Method.Name |> function "isIn" -> In | _ -> NotIn
             match m.Arguments.[0], m.Arguments.[1] with
             | Property p, MethodCall lst ->
-                let lstValues = unwrapListExpr ([], lst)                
+                let lstValues = unwrapListExpr ([], lst)
                 Column (qualifyColumn p, comparisonType lstValues)
-            | Property p, Value value -> 
+            | Property p, Value value ->
                 let lstValues = (value :?> System.Collections.IEnumerable) |> Seq.cast<obj> |> Seq.toList
                 Column (qualifyColumn p, comparisonType lstValues)
             | _ -> notImpl()
         | MethodCall m when List.contains m.Method.Name [ "like"; "notLike" ] ->
             match m.Arguments.[0], m.Arguments.[1] with
-            | Property p, Value value -> 
+            | Property p, ValueOrParameterSubstitute sub value ->
                 let pattern = string value
                 match m.Method.Name with
                 | "like" -> Column ((qualifyColumn p), (Like pattern))
@@ -226,42 +287,58 @@ let visitWhere<'T> (filter: Expression<Func<'T, bool>>) (qualifyColumn: MemberIn
             | _ -> notImpl()
         | MethodCall m when m.Method.Name = "isNullValue" || m.Method.Name = "isNotNullValue" ->
             match m.Arguments.[0] with
-            | Property p -> 
-                if m.Method.Name = "isNullValue" 
+            | Property p ->
+                if m.Method.Name = "isNullValue"
                 then Column (qualifyColumn p, ColumnComparison.IsNull)
                 else Column (qualifyColumn p, ColumnComparison.IsNotNull)
             | _ -> notImpl()
+        // support pattern match
+        | GetTagCondition b -> if b then True else False
         | BinaryAnd x ->
-            let lt = visit x.Left
-            let rt = visit x.Right
-            Binary (lt, And, rt)
-        | BinaryOr x -> 
-            let lt = visit x.Left
-            let rt = visit x.Right
-            Binary (lt, Or, rt)
+            match visit x.Left with
+            | False -> False // short circuit, because `if c then x else false` is converted to c && x
+            | lt ->
+                let rt = visit x.Right
+                Binary (lt, And, rt)
+        | BinaryOr x ->
+            match visit x.Left with
+            | True -> True // short circuit, because `if c then true else x` is converted to c || x
+            | lt ->
+                let rt = visit x.Right
+                Binary (lt, Or, rt)
         | BinaryCompare x ->
-            match x.Left, x.Right with            
+            match x.Left, x.Right with
             | Property p1, Property p2 ->
                 // Handle col to col comparisons
                 let lt = qualifyColumn p1
                 let cp = getComparison exp.NodeType
                 let rt = qualifyColumn p2
                 Expr (sprintf "%s %s %s" lt cp rt)
-            | Property p, Value value
-            | Value value, Property p ->
+            | Property p, ValueOrParameterSubstitute sub value
+            | ValueOrParameterSubstitute sub value, Property p ->
                 // Handle column to value comparisons
                 let columnComparison = getColumnComparison(exp.NodeType, value)
                 Column (qualifyColumn p, columnComparison)
-            | Value v1, Value v2 ->
+            | ValueOrParameterSubstitute sub v1, ValueOrParameterSubstitute sub v2 when (v1 :? int) && (v2 :? int) -> if (getComparisonOp exp.NodeType) (v1 :?> int) (v2 :?> int) then True else False
+            | ValueOrParameterSubstitute sub v1, ValueOrParameterSubstitute sub v2 when (v1 :? bool) && (v2 :? bool) -> if (getComparisonOp exp.NodeType) (v1 :?> bool) (v2 :?> bool) then True else False
+            | ValueOrParameterSubstitute sub v1, ValueOrParameterSubstitute sub v2 ->
                 // Not implemented because I didn't want to embed logic to properly format strings, dates, etc.
                 // This can be easily added later if it is implemented in Dapper.FSharp.
-                notImplMsg("Value to value comparisons are not currently supported. Ex: where (1 = 1)")
+                notImplMsg("Value to value comparisons are currently supported only for int and bool. Ex: where (1 = 1)")
             | _ ->
                 notImpl()
+        | IfElse x ->
+            match visit x.Test with
+            | True ->
+                visit x.IfTrue
+            | False ->
+                visit x.IfFalse
+            | _ -> notImplMsg "Only boolean constant as condition is supported."
+
         | _ ->
             notImpl()
 
-    visit (filter :> Expression)
+    visitSubParam Map.empty (filter :> Expression)
 
 /// Returns a list of one or more fully qualified column names: ["{schema}.{table}.{column}"]
 let visitGroupBy<'T, 'Prop> (propertySelector: Expression<Func<'T, 'Prop>>) (qualifyColumn: MemberInfo -> string) =

--- a/src/Dapper.FSharp/SQLite/WhereAnalyzer.fs
+++ b/src/Dapper.FSharp/SQLite/WhereAnalyzer.fs
@@ -30,7 +30,9 @@ let normalizeParamName (s:string) = s.Replace(".","_")
 
 let rec getWhereMetadata (meta:FieldWhereMetadata list) (w:Where)  =
     match w with
-    | Empty -> meta
+    | Empty
+    | True
+    | False
     | Expr _ -> meta
     | Column (field, comp) ->
         let parName =

--- a/tests/Dapper.FSharp.Tests/Dapper.FSharp.Tests.fsproj
+++ b/tests/Dapper.FSharp.Tests/Dapper.FSharp.Tests.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="PostgreSQL\UpdateTests.fs" />
     <Compile Include="PostgreSQL\InsertTests.fs" />
     <Compile Include="PostgreSQL\SelectTests.fs" />
+    <Compile Include="PostgreSQL\WhereTests.fs" />
     
     <Compile Include="MySQL\Database.fs" />
     <Compile Include="MySQL\DeleteTests.fs" />

--- a/tests/Dapper.FSharp.Tests/Dapper.FSharp.Tests.fsproj
+++ b/tests/Dapper.FSharp.Tests/Dapper.FSharp.Tests.fsproj
@@ -38,6 +38,7 @@
     <Compile Include="MSSQL\UpdateTests.fs" />
     <Compile Include="MSSQL\InsertTests.fs" />
     <Compile Include="MSSQL\SelectTests.fs" />
+    <Compile Include="MSSQL\WhereTests.fs" />
 	  
     <Compile Include="SQLite\Database.fs" />
     <Compile Include="SQLite\DeleteTests.fs" />

--- a/tests/Dapper.FSharp.Tests/Dapper.FSharp.Tests.fsproj
+++ b/tests/Dapper.FSharp.Tests/Dapper.FSharp.Tests.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="MySQL\UpdateTests.fs" />
     <Compile Include="MySQL\InsertTests.fs" />
     <Compile Include="MySQL\SelectTests.fs" />
+    <Compile Include="MySQL\WhereTests.fs" />
       
     <Compile Include="MSSQL\Database.fs" />
     <Compile Include="MSSQL\DeleteTests.fs" />

--- a/tests/Dapper.FSharp.Tests/Dapper.FSharp.Tests.fsproj
+++ b/tests/Dapper.FSharp.Tests/Dapper.FSharp.Tests.fsproj
@@ -49,6 +49,7 @@
     <Compile Include="SQLite\UpdateTests.fs" />
     <Compile Include="SQLite\InsertTests.fs" />
     <Compile Include="SQLite\SelectTests.fs" />
+    <Compile Include="SQLite\WhereTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dapper.FSharp\Dapper.FSharp.fsproj" />

--- a/tests/Dapper.FSharp.Tests/MSSQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/SelectTests.fs
@@ -306,53 +306,6 @@ type SelectTests () =
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
         }
 
-    [<TestCase(2)>]
-    [<TestCase(7)>]
-    [<TestCase(null)>]
-    member _.``Selects by where condition with IF`` x =
-        let o = x |> Option.ofNullable
-        task {
-            do! init.InitPersons()
-            let rs = Persons.View.generate 10
-            let! _ =
-                insert {
-                    into personsView
-                    values rs
-                } |> conn.InsertAsync
-            let! fromDb =
-                let cond = o.IsSome
-                select {
-                    for p in personsView do
-                    where (if cond then (p.Position > o.Value) else false)
-                } |> conn.SelectAsync<Persons.View>
-
-            let expected = 10 - (o |> Option.defaultValue 10)
-            Assert.AreEqual (expected, Seq.length fromDb)
-        }
-
-    [<TestCase(2)>]
-    [<TestCase(7)>]
-    [<TestCase(null)>]
-    member _.``Selects by where condition with match option`` x =
-        let o = x |> Option.ofNullable
-        task {
-            do! init.InitPersons()
-            let rs = Persons.View.generate 10
-            let! _ =
-                insert {
-                    into personsView
-                    values rs
-                } |> conn.InsertAsync
-            let! fromDb =
-                select {
-                    for p in personsView do
-                    where (match o with | Some x -> p.Position > x | None -> true)
-                } |> conn.SelectAsync<Persons.View>
-
-            let expected = 10 - (o |> Option.defaultValue 0)
-            Assert.AreEqual (expected, Seq.length fromDb)
-        }
-
     [<Test>]
     member _.``Selects with order by``() =
         task {

--- a/tests/Dapper.FSharp.Tests/MSSQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/SelectTests.fs
@@ -305,7 +305,54 @@ type SelectTests () =
             
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
         }
-    
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with IF`` x =
+        let o = x |> Option.ofNullable
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                let cond = o.IsSome
+                select {
+                    for p in personsView do
+                    where (if cond then (p.Position > o.Value) else false)
+                } |> conn.SelectAsync<Persons.View>
+
+            let expected = 10 - (o |> Option.defaultValue 10)
+            Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with match option`` x =
+        let o = x |> Option.ofNullable
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (match o with | Some x -> p.Position > x | None -> true)
+                } |> conn.SelectAsync<Persons.View>
+
+            let expected = 10 - (o |> Option.defaultValue 0)
+            Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
     [<Test>]
     member _.``Selects with order by``() =
         task {

--- a/tests/Dapper.FSharp.Tests/MSSQL/WhereTests.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/WhereTests.fs
@@ -1,0 +1,109 @@
+﻿module Dapper.FSharp.Tests.MSSQL.WhereTests
+
+open System.Threading
+open System.Threading.Tasks
+open NUnit.Framework
+open Dapper.FSharp.MSSQL
+open Dapper.FSharp.Tests.Database
+
+[<TestFixture>]
+[<NonParallelizable>]
+type WhereTests () =
+    
+    let personsView = table'<Persons.View> "Persons"
+    let conn = Database.getConnection()
+    let init = Database.getInitializer conn
+
+    let whereTest selectQuery =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                selectQuery |> conn.SelectAsync<Persons.View>
+            return fromDb
+        }
+    
+    [<OneTimeSetUp>]
+    member _.``Setup DB``() = conn |> Database.safeInit
+        
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with IF`` x = task {
+        let o = x |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                let cond = o.IsSome
+                select {
+                    for p in personsView do
+                    where (if cond then (p.Position > o.Value) else false)
+                })
+
+        let expected = 10 - (o |> Option.defaultValue 10)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with match option`` x = task {
+        let o = x |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (match o with | Some x -> p.Position > x | None -> true)
+                })
+
+        let expected = 10 - (o |> Option.defaultValue 0)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2, null)>]
+    [<TestCase(null, 7)>]
+    [<TestCase(2,4)>]
+    [<TestCase(5,9)>]
+    [<TestCase(7,7)>]
+    [<TestCase(null, null)>]
+    member _.``Selects by where condition with ANDed match options`` (x1, x2) = task {
+        let lb = x1 |> Option.ofNullable
+        let ub = x2 |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (
+                        (match lb with | Some x -> p.Position > x | None -> true)
+                            && (match ub with | Some x -> p.Position < x | None -> true))
+                })
+
+        let expected = max 0 ((ub |> Option.defaultValue 11) - (lb |> Option.defaultValue 0) - 1)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2, null)>]
+    [<TestCase(null, 7)>]
+    [<TestCase(4,2)>]
+    [<TestCase(9,5)>]
+    [<TestCase(7,3)>]
+    [<TestCase(null, null)>]
+    member _.``Selects by where condition with ORed match options`` (x1, x2) = task {
+        let lb = x1 |> Option.ofNullable
+        let ub = x2 |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (
+                        (match lb with | Some x -> p.Position > x | None -> false)
+                        || (match ub with | Some x -> p.Position < x | None -> false))
+                })
+
+        let expected = min 10 (((ub |> Option.defaultValue 1) - 1) + (10 - (lb |> Option.defaultValue 10)))
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }

--- a/tests/Dapper.FSharp.Tests/MySQL/WhereTests.fs
+++ b/tests/Dapper.FSharp.Tests/MySQL/WhereTests.fs
@@ -1,0 +1,155 @@
+﻿module Dapper.FSharp.Tests.MySQL.WhereTests
+
+open System
+open System.Threading
+open System.Threading.Tasks
+open NUnit.Framework
+open Dapper.FSharp.MySQL
+open Dapper.FSharp.Tests.Database
+
+type CustomDU =
+    | PositionBetween of int * int
+    | Name of string
+    | NoDate
+
+[<TestFixture>]
+[<NonParallelizable>]
+type WhereTests () =
+
+    let personsView = table'<Persons.View> "Persons"
+    let conn = Database.getConnection()
+    let init = Database.getInitializer conn
+
+    let whereTest selectQuery =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                selectQuery |> conn.SelectAsync<Persons.View>
+            return fromDb
+        }
+
+    [<OneTimeSetUp>]
+    member _.``Setup DB``() = conn |> Database.safeInit
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with IF`` x = task {
+        let o = x |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                let cond = o.IsSome
+                select {
+                    for p in personsView do
+                    where (if cond then (p.Position > o.Value) else false)
+                })
+
+        let expected = 10 - (o |> Option.defaultValue 10)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with match option`` x = task {
+        let o = x |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (match o with | Some x -> p.Position > x | None -> true)
+                })
+
+        let expected = 10 - (o |> Option.defaultValue 0)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2, null)>]
+    [<TestCase(null, 7)>]
+    [<TestCase(2,4)>]
+    [<TestCase(5,9)>]
+    [<TestCase(7,7)>]
+    [<TestCase(null, null)>]
+    member _.``Selects by where condition with ANDed match options`` (x1, x2) = task {
+        let lb = x1 |> Option.ofNullable
+        let ub = x2 |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (
+                        (match lb with | Some x -> p.Position > x | None -> true)
+                            && (match ub with | Some x -> p.Position < x | None -> true))
+                })
+
+        let expected = max 0 ((ub |> Option.defaultValue 11) - (lb |> Option.defaultValue 0) - 1)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2, null)>]
+    [<TestCase(null, 7)>]
+    [<TestCase(4,2)>]
+    [<TestCase(9,5)>]
+    [<TestCase(7,3)>]
+    [<TestCase(null, null)>]
+    member _.``Selects by where condition with ORed match options`` (x1, x2) = task {
+        let lb = x1 |> Option.ofNullable
+        let ub = x2 |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (
+                        (match lb with | Some x -> p.Position > x | None -> false)
+                        || (match ub with | Some x -> p.Position < x | None -> false))
+                })
+
+        let expected = min 10 (((ub |> Option.defaultValue 1) - 1) + (10 - (lb |> Option.defaultValue 10)))
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with match result`` x = task {
+        let o = x |> Option.ofNullable |> Option.map Ok |> Option.defaultValue (Error "error")
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (match o with | Ok x -> p.Position > x | Error e -> false)
+                })
+
+        let expected = 10 - (o |> Result.defaultValue 10)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2, 7, null, null)>]
+    [<TestCase(null, null, "First_1%", null)>]
+    [<TestCase(null, null, null, true)>]
+    member _.``Selects by where condition with match custom DU`` (p1, p2, n, d) = task {
+        let o =
+            match Option.ofNullable p1, Option.ofNullable p2, n, d with
+            | Some lb, Some ub, _, _ -> PositionBetween (lb, ub)
+            | _, _, x, _ when x <> null -> Name x
+            | _, _, _, true -> NoDate
+            | _ -> failwith "invalid test case"
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (match o with | PositionBetween (lb, ub) -> p.Position > lb && p.Position < ub | Name n -> like p.FirstName n | NoDate -> p.DateOfBirth = None)
+                })
+
+        match o with
+        | PositionBetween (lb, ub) -> Assert.AreEqual (ub - lb - 1, Seq.length fromDb)
+        | Name "First_1%" -> Assert.AreEqual (2, Seq.length fromDb)
+        | NoDate -> Assert.AreEqual (5, Seq.length fromDb)
+        | _ -> Assert.Fail "invalid test case"
+        }

--- a/tests/Dapper.FSharp.Tests/PostgreSQL/WhereTests.fs
+++ b/tests/Dapper.FSharp.Tests/PostgreSQL/WhereTests.fs
@@ -1,0 +1,155 @@
+﻿module Dapper.FSharp.Tests.PostgreSQL.WhereTests
+
+open System
+open System.Threading
+open System.Threading.Tasks
+open NUnit.Framework
+open Dapper.FSharp.PostgreSQL
+open Dapper.FSharp.Tests.Database
+
+type CustomDU =
+    | PositionBetween of int * int
+    | Name of string
+    | NoDate
+
+[<TestFixture>]
+[<NonParallelizable>]
+type WhereTests () =
+
+    let personsView = table'<Persons.View> "Persons"
+    let conn = Database.getConnection()
+    let init = Database.getInitializer conn
+
+    let whereTest selectQuery =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                selectQuery |> conn.SelectAsync<Persons.View>
+            return fromDb
+        }
+
+    [<OneTimeSetUp>]
+    member _.``Setup DB``() = conn |> Database.safeInit
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with IF`` x = task {
+        let o = x |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                let cond = o.IsSome
+                select {
+                    for p in personsView do
+                    where (if cond then (p.Position > o.Value) else false)
+                })
+
+        let expected = 10 - (o |> Option.defaultValue 10)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with match option`` x = task {
+        let o = x |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (match o with | Some x -> p.Position > x | None -> true)
+                })
+
+        let expected = 10 - (o |> Option.defaultValue 0)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2, null)>]
+    [<TestCase(null, 7)>]
+    [<TestCase(2,4)>]
+    [<TestCase(5,9)>]
+    [<TestCase(7,7)>]
+    [<TestCase(null, null)>]
+    member _.``Selects by where condition with ANDed match options`` (x1, x2) = task {
+        let lb = x1 |> Option.ofNullable
+        let ub = x2 |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (
+                        (match lb with | Some x -> p.Position > x | None -> true)
+                            && (match ub with | Some x -> p.Position < x | None -> true))
+                })
+
+        let expected = max 0 ((ub |> Option.defaultValue 11) - (lb |> Option.defaultValue 0) - 1)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2, null)>]
+    [<TestCase(null, 7)>]
+    [<TestCase(4,2)>]
+    [<TestCase(9,5)>]
+    [<TestCase(7,3)>]
+    [<TestCase(null, null)>]
+    member _.``Selects by where condition with ORed match options`` (x1, x2) = task {
+        let lb = x1 |> Option.ofNullable
+        let ub = x2 |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (
+                        (match lb with | Some x -> p.Position > x | None -> false)
+                        || (match ub with | Some x -> p.Position < x | None -> false))
+                })
+
+        let expected = min 10 (((ub |> Option.defaultValue 1) - 1) + (10 - (lb |> Option.defaultValue 10)))
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with match result`` x = task {
+        let o = x |> Option.ofNullable |> Option.map Ok |> Option.defaultValue (Error "error")
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (match o with | Ok x -> p.Position > x | Error e -> false)
+                })
+
+        let expected = 10 - (o |> Result.defaultValue 10)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2, 7, null, null)>]
+    [<TestCase(null, null, "First_1%", null)>]
+    [<TestCase(null, null, null, true)>]
+    member _.``Selects by where condition with match custom DU`` (p1, p2, n, d) = task {
+        let o =
+            match Option.ofNullable p1, Option.ofNullable p2, n, d with
+            | Some lb, Some ub, _, _ -> PositionBetween (lb, ub)
+            | _, _, x, _ when x <> null -> Name x
+            | _, _, _, true -> NoDate
+            | _ -> failwith "invalid test case"
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (match o with | PositionBetween (lb, ub) -> p.Position > lb && p.Position < ub | Name n -> like p.FirstName n | NoDate -> p.DateOfBirth = None)
+                })
+
+        match o with
+        | PositionBetween (lb, ub) -> Assert.AreEqual (ub - lb - 1, Seq.length fromDb)
+        | Name "First_1%" -> Assert.AreEqual (2, Seq.length fromDb)
+        | NoDate -> Assert.AreEqual (5, Seq.length fromDb)
+        | _ -> Assert.Fail "invalid test case"
+        }

--- a/tests/Dapper.FSharp.Tests/SQLite/WhereTests.fs
+++ b/tests/Dapper.FSharp.Tests/SQLite/WhereTests.fs
@@ -1,0 +1,155 @@
+﻿module Dapper.FSharp.Tests.SQLite.WhereTests
+
+open System
+open System.Threading
+open System.Threading.Tasks
+open NUnit.Framework
+open Dapper.FSharp.SQLite
+open Dapper.FSharp.Tests.Database
+
+type CustomDU =
+    | PositionBetween of int * int
+    | Name of string
+    | NoDate
+
+[<TestFixture>]
+[<NonParallelizable>]
+type WhereTests () =
+
+    let personsView = table'<Persons.View> "Persons"
+    let conn = Database.getConnection()
+    let init = Database.getInitializer conn
+
+    let whereTest selectQuery =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                selectQuery |> conn.SelectAsync<Persons.View>
+            return fromDb
+        }
+
+    [<OneTimeSetUp>]
+    member _.``Setup DB``() = conn |> Database.safeInit
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with IF`` x = task {
+        let o = x |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                let cond = o.IsSome
+                select {
+                    for p in personsView do
+                    where (if cond then (p.Position > o.Value) else false)
+                })
+
+        let expected = 10 - (o |> Option.defaultValue 10)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with match option`` x = task {
+        let o = x |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (match o with | Some x -> p.Position > x | None -> true)
+                })
+
+        let expected = 10 - (o |> Option.defaultValue 0)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2, null)>]
+    [<TestCase(null, 7)>]
+    [<TestCase(2,4)>]
+    [<TestCase(5,9)>]
+    [<TestCase(7,7)>]
+    [<TestCase(null, null)>]
+    member _.``Selects by where condition with ANDed match options`` (x1, x2) = task {
+        let lb = x1 |> Option.ofNullable
+        let ub = x2 |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (
+                        (match lb with | Some x -> p.Position > x | None -> true)
+                            && (match ub with | Some x -> p.Position < x | None -> true))
+                })
+
+        let expected = max 0 ((ub |> Option.defaultValue 11) - (lb |> Option.defaultValue 0) - 1)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2, null)>]
+    [<TestCase(null, 7)>]
+    [<TestCase(4,2)>]
+    [<TestCase(9,5)>]
+    [<TestCase(7,3)>]
+    [<TestCase(null, null)>]
+    member _.``Selects by where condition with ORed match options`` (x1, x2) = task {
+        let lb = x1 |> Option.ofNullable
+        let ub = x2 |> Option.ofNullable
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (
+                        (match lb with | Some x -> p.Position > x | None -> false)
+                        || (match ub with | Some x -> p.Position < x | None -> false))
+                })
+
+        let expected = min 10 (((ub |> Option.defaultValue 1) - 1) + (10 - (lb |> Option.defaultValue 10)))
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2)>]
+    [<TestCase(7)>]
+    [<TestCase(null)>]
+    member _.``Selects by where condition with match result`` x = task {
+        let o = x |> Option.ofNullable |> Option.map Ok |> Option.defaultValue (Error "error")
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (match o with | Ok x -> p.Position > x | Error e -> false)
+                })
+
+        let expected = 10 - (o |> Result.defaultValue 10)
+        Assert.AreEqual (expected, Seq.length fromDb)
+        }
+
+    [<TestCase(2, 7, null, null)>]
+    [<TestCase(null, null, "First_1%", null)>]
+    [<TestCase(null, null, null, true)>]
+    member _.``Selects by where condition with match custom DU`` (p1, p2, n, d) = task {
+        let o =
+            match Option.ofNullable p1, Option.ofNullable p2, n, d with
+            | Some lb, Some ub, _, _ -> PositionBetween (lb, ub)
+            | _, _, x, _ when x <> null -> Name x
+            | _, _, _, true -> NoDate
+            | _ -> failwith "invalid test case"
+        let! fromDb =
+            whereTest (
+                select {
+                    for p in personsView do
+                    where (match o with | PositionBetween (lb, ub) -> p.Position > lb && p.Position < ub | Name n -> like p.FirstName n | NoDate -> p.DateOfBirth = None)
+                })
+
+        match o with
+        | PositionBetween (lb, ub) -> Assert.AreEqual (ub - lb - 1, Seq.length fromDb)
+        | Name "First_1%" -> Assert.AreEqual (2, Seq.length fromDb)
+        | NoDate -> Assert.AreEqual (5, Seq.length fromDb)
+        | _ -> Assert.Fail "invalid test case"
+        }


### PR DESCRIPTION
Main motivation for this feature is combining `where` condition from optional parameters:

```F#
select {
    for p in personTable do
    where (
        (match positionGTFilter with | Some x -> p.Position > x | None -> true)
        && (match positionLTFilter with | Some x -> p.Position < x | None -> true)
        && (match firstNameFilter with | Some x -> like p.FirstName x | None -> true))
} |> conn.SelectAsync<Person>
```

It's adding support for:
- `if` ... `then` ... `else`, where condition needs to be of `bool` type
- boolean literals (`true`, `false`)
- pattern match
  - fun fact: `match` expression is actually translated to `if` expressions in `Linq.Expression`
  - `Option`, `Result` and simple custom DU is covered by tests, its quite possible there is more corner cases that's not covered by this
  - to make this work, I needed to add binding substitution to `visitWhere` (so we are able to replace `x` with value from `positionGTFilter` in `p.Position > x`. It can be used to support lambda functions in other use cases in the future.

✅Whole test suite is green on MyComputer™.