### PR TITLE
andWhere, orWhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,14 +286,14 @@ select {
 } |> conn.SelectAsync<Person>
 ```
 
-You can also combine multiple `where` conditions with `whereAnd` and `whereOr`:
+You can also combine multiple `where` conditions with `andWhere` and `orWhere`:
 
 ```F#
 select {
     for p in personTable do
     where (p.Position > 5)
-    whereAnd (p.Position < 10)
-    whereOr (p.Position < 2)
+    andWhere (p.Position < 10)
+    orWhere (p.Position < 2)
 } |> conn.SelectAsync<Person>
 ```
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,17 @@ select {
 } |> conn.SelectAsync<Person>
 ```
 
+You can also combine multiple `where` conditions with `whereAnd` and `whereOr`:
+
+```F#
+select {
+    for p in personTable do
+    where (p.Position > 5)
+    whereAnd (p.Position < 10)
+    whereOr (p.Position < 2)
+} |> conn.SelectAsync<Person>
+```
+
 NOTE: Do not use the forward pipe `|>` operator in your query expressions because it's not implemented, so don't do it (unless you like exceptions)!
 
 To use LIKE operator in `where` condition, use `like`:

--- a/src/Dapper.FSharp/MSSQL/Builders.fs
+++ b/src/Dapper.FSharp/MSSQL/Builders.fs
@@ -105,6 +105,20 @@ type SelectExpressionBuilder<'T>() =
         let where = LinqExpressionVisitors.visitWhere<'T> whereExpression (fullyQualifyColumn state.TableMappings)
         QuerySource<'T, SelectQuery>({ query with Where = where }, state.TableMappings)
 
+    /// Combine existing WHERE condition with AND
+    [<CustomOperation("whereAnd", MaintainsVariableSpace = true)>]
+    member this.WhereAnd (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = lazy this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, And, state2.Value.Query.Where)
+        QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
+
+    /// Combine existing WHERE condition with OR
+    [<CustomOperation("whereOr", MaintainsVariableSpace = true)>]
+    member this.WhereOr (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = lazy this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, Or, state2.Value.Query.Where)
+        QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
+
     /// Sets the ORDER BY for single column
     [<CustomOperation("orderBy", MaintainsVariableSpace = true)>]
     member this.OrderBy (state:QuerySource<'T>, [<ProjectionParameter>] propertySelector) = 

--- a/src/Dapper.FSharp/MSSQL/Builders.fs
+++ b/src/Dapper.FSharp/MSSQL/Builders.fs
@@ -106,17 +106,17 @@ type SelectExpressionBuilder<'T>() =
         QuerySource<'T, SelectQuery>({ query with Where = where }, state.TableMappings)
 
     /// Combine existing WHERE condition with AND
-    [<CustomOperation("whereAnd", MaintainsVariableSpace = true)>]
-    member this.WhereAnd (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
-        let state2 = lazy this.Where(state, whereExpression)
-        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, And, state2.Value.Query.Where)
+    [<CustomOperation("andWhere", MaintainsVariableSpace = true)>]
+    member this.AndWhere (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, And, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
     /// Combine existing WHERE condition with OR
-    [<CustomOperation("whereOr", MaintainsVariableSpace = true)>]
-    member this.WhereOr (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
-        let state2 = lazy this.Where(state, whereExpression)
-        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, Or, state2.Value.Query.Where)
+    [<CustomOperation("orWhere", MaintainsVariableSpace = true)>]
+    member this.OrWhere (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, Or, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
     /// Sets the ORDER BY for single column

--- a/src/Dapper.FSharp/MySQL/Builders.fs
+++ b/src/Dapper.FSharp/MySQL/Builders.fs
@@ -103,6 +103,20 @@ type SelectExpressionBuilder<'T>() =
         let where = LinqExpressionVisitors.visitWhere<'T> whereExpression (fullyQualifyColumn state.TableMappings)
         QuerySource<'T, SelectQuery>({ query with Where = where }, state.TableMappings)
 
+    /// Combine existing WHERE condition with AND
+    [<CustomOperation("whereAnd", MaintainsVariableSpace = true)>]
+    member this.WhereAnd (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = lazy this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, And, state2.Value.Query.Where)
+        QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
+
+    /// Combine existing WHERE condition with OR
+    [<CustomOperation("whereOr", MaintainsVariableSpace = true)>]
+    member this.WhereOr (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = lazy this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, Or, state2.Value.Query.Where)
+        QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
+
     /// Sets the ORDER BY for single column
     [<CustomOperation("orderBy", MaintainsVariableSpace = true)>]
     member this.OrderBy (state:QuerySource<'T>, [<ProjectionParameter>] propertySelector) = 

--- a/src/Dapper.FSharp/MySQL/Builders.fs
+++ b/src/Dapper.FSharp/MySQL/Builders.fs
@@ -104,17 +104,17 @@ type SelectExpressionBuilder<'T>() =
         QuerySource<'T, SelectQuery>({ query with Where = where }, state.TableMappings)
 
     /// Combine existing WHERE condition with AND
-    [<CustomOperation("whereAnd", MaintainsVariableSpace = true)>]
-    member this.WhereAnd (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
-        let state2 = lazy this.Where(state, whereExpression)
-        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, And, state2.Value.Query.Where)
+    [<CustomOperation("andWhere", MaintainsVariableSpace = true)>]
+    member this.AndWhere (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, And, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
     /// Combine existing WHERE condition with OR
-    [<CustomOperation("whereOr", MaintainsVariableSpace = true)>]
-    member this.WhereOr (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
-        let state2 = lazy this.Where(state, whereExpression)
-        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, Or, state2.Value.Query.Where)
+    [<CustomOperation("orWhere", MaintainsVariableSpace = true)>]
+    member this.OrWhere (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, Or, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
     /// Sets the ORDER BY for single column

--- a/src/Dapper.FSharp/PostgreSQL/Builders.fs
+++ b/src/Dapper.FSharp/PostgreSQL/Builders.fs
@@ -103,17 +103,17 @@ type SelectExpressionBuilder<'T>() =
         QuerySource<'T, SelectQuery>({ query with Where = where }, state.TableMappings)
 
     /// Combine existing WHERE condition with AND
-    [<CustomOperation("whereAnd", MaintainsVariableSpace = true)>]
-    member this.WhereAnd (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
-        let state2 = lazy this.Where(state, whereExpression)
-        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, And, state2.Value.Query.Where)
+    [<CustomOperation("andWhere", MaintainsVariableSpace = true)>]
+    member this.AndWhere (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, And, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
     /// Combine existing WHERE condition with OR
-    [<CustomOperation("whereOr", MaintainsVariableSpace = true)>]
-    member this.WhereOr (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
-        let state2 = lazy this.Where(state, whereExpression)
-        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, Or, state2.Value.Query.Where)
+    [<CustomOperation("orWhere", MaintainsVariableSpace = true)>]
+    member this.OrWhere (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, Or, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
     /// Sets the ORDER BY for single column

--- a/src/Dapper.FSharp/PostgreSQL/Builders.fs
+++ b/src/Dapper.FSharp/PostgreSQL/Builders.fs
@@ -102,6 +102,20 @@ type SelectExpressionBuilder<'T>() =
         let where = visitWhere<'T> whereExpression (fullyQualifyColumn state.TableMappings)
         QuerySource<'T, SelectQuery>({ query with Where = where }, state.TableMappings)
 
+    /// Combine existing WHERE condition with AND
+    [<CustomOperation("whereAnd", MaintainsVariableSpace = true)>]
+    member this.WhereAnd (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = lazy this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, And, state2.Value.Query.Where)
+        QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
+
+    /// Combine existing WHERE condition with OR
+    [<CustomOperation("whereOr", MaintainsVariableSpace = true)>]
+    member this.WhereOr (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = lazy this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, Or, state2.Value.Query.Where)
+        QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
+
     /// Sets the ORDER BY for single column
     [<CustomOperation("orderBy", MaintainsVariableSpace = true)>]
     member this.OrderBy (state:QuerySource<'T>, [<ProjectionParameter>] propertySelector) = 

--- a/src/Dapper.FSharp/SQLite/Builders.fs
+++ b/src/Dapper.FSharp/SQLite/Builders.fs
@@ -94,17 +94,17 @@ type SelectExpressionBuilder<'T>() =
         QuerySource<'T, SelectQuery>({ query with Where = where }, state.TableMappings)
 
     /// Combine existing WHERE condition with AND
-    [<CustomOperation("whereAnd", MaintainsVariableSpace = true)>]
-    member this.WhereAnd (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
-        let state2 = lazy this.Where(state, whereExpression)
-        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, And, state2.Value.Query.Where)
+    [<CustomOperation("andWhere", MaintainsVariableSpace = true)>]
+    member this.AndWhere (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, And, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
     /// Combine existing WHERE condition with OR
-    [<CustomOperation("whereOr", MaintainsVariableSpace = true)>]
-    member this.WhereOr (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
-        let state2 = lazy this.Where(state, whereExpression)
-        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, Or, state2.Value.Query.Where)
+    [<CustomOperation("orWhere", MaintainsVariableSpace = true)>]
+    member this.OrWhere (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, Or, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
     /// Sets the ORDER BY for single column

--- a/src/Dapper.FSharp/SQLite/Builders.fs
+++ b/src/Dapper.FSharp/SQLite/Builders.fs
@@ -93,6 +93,20 @@ type SelectExpressionBuilder<'T>() =
         let where = LinqExpressionVisitors.visitWhere<'T> whereExpression (fullyQualifyColumn state.TableMappings)
         QuerySource<'T, SelectQuery>({ query with Where = where }, state.TableMappings)
 
+    /// Combine existing WHERE condition with AND
+    [<CustomOperation("whereAnd", MaintainsVariableSpace = true)>]
+    member this.WhereAnd (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = lazy this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, And, state2.Value.Query.Where)
+        QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
+
+    /// Combine existing WHERE condition with OR
+    [<CustomOperation("whereOr", MaintainsVariableSpace = true)>]
+    member this.WhereOr (state: QuerySource<'T, SelectQuery>, [<ProjectionParameter>] whereExpression ) =
+        let state2 = lazy this.Where(state, whereExpression)
+        let where2 = if state.Query.Where = Where.Empty then state2.Value.Query.Where else Binary(state.Query.Where, Or, state2.Value.Query.Where)
+        QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
+
     /// Sets the ORDER BY for single column
     [<CustomOperation("orderBy", MaintainsVariableSpace = true)>]
     member this.OrderBy (state:QuerySource<'T>, [<ProjectionParameter>] propertySelector) = 

--- a/tests/Dapper.FSharp.Tests/MSSQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/SelectTests.fs
@@ -305,7 +305,89 @@ type SelectTests () =
             
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
         }
-    
+
+    [<Test>]
+    member _.``Selects by whereAnd``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position > 2)
+                    whereAnd (p.Position < 4)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
+            Assert.AreEqual(1, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by whereOr``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position < 2)
+                    whereOr (p.Position > 8)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual(3, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by just whereAnd``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    whereAnd (p.Position < 2)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual (rs |> List.find (fun x -> x.Position = 1), Seq.head fromDb)
+            Assert.AreEqual(1, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by whereAnd and whereOr``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position > 2)
+                    whereAnd (p.Position < 4)
+                    whereOr (p.Position > 9)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual(2, Seq.length fromDb)
+        }
+
     [<Test>]
     member _.``Selects with order by``() =
         task {

--- a/tests/Dapper.FSharp.Tests/MSSQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/SelectTests.fs
@@ -307,7 +307,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereAnd``() =
+    member _.``Selects by andWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -320,7 +320,7 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position > 2)
-                    whereAnd (p.Position < 4)
+                    andWhere (p.Position < 4)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
@@ -328,7 +328,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereOr``() =
+    member _.``Selects by orWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -341,14 +341,14 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position < 2)
-                    whereOr (p.Position > 8)
+                    orWhere (p.Position > 8)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual(3, Seq.length fromDb)
         }
 
     [<Test>]
-    member _.``Selects by just whereAnd``() =
+    member _.``Selects by just andWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -360,7 +360,7 @@ type SelectTests () =
             let! fromDb =
                 select {
                     for p in personsView do
-                    whereAnd (p.Position < 2)
+                    andWhere (p.Position < 2)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 1), Seq.head fromDb)
@@ -368,7 +368,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereAnd and whereOr``() =
+    member _.``Selects by andWhere and orWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -381,8 +381,8 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position > 2)
-                    whereAnd (p.Position < 4)
-                    whereOr (p.Position > 9)
+                    andWhere (p.Position < 4)
+                    orWhere (p.Position > 9)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual(2, Seq.length fromDb)

--- a/tests/Dapper.FSharp.Tests/MySQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/MySQL/SelectTests.fs
@@ -305,7 +305,89 @@ type SelectTests () =
             
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
         }
-    
+
+    [<Test>]
+    member _.``Selects by whereAnd``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position > 2)
+                    whereAnd (p.Position < 4)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
+            Assert.AreEqual(1, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by whereOr``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position < 2)
+                    whereOr (p.Position > 8)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual(3, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by just whereAnd``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    whereAnd (p.Position < 2)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual (rs |> List.find (fun x -> x.Position = 1), Seq.head fromDb)
+            Assert.AreEqual(1, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by whereAnd and whereOr``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position > 2)
+                    whereAnd (p.Position < 4)
+                    whereOr (p.Position > 9)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual(2, Seq.length fromDb)
+        }
+
     [<Test>]
     member _.``Selects with order by``() =
         task {

--- a/tests/Dapper.FSharp.Tests/MySQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/MySQL/SelectTests.fs
@@ -307,7 +307,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereAnd``() =
+    member _.``Selects by andWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -320,7 +320,7 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position > 2)
-                    whereAnd (p.Position < 4)
+                    andWhere (p.Position < 4)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
@@ -328,7 +328,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereOr``() =
+    member _.``Selects by orWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -341,14 +341,14 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position < 2)
-                    whereOr (p.Position > 8)
+                    orWhere (p.Position > 8)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual(3, Seq.length fromDb)
         }
 
     [<Test>]
-    member _.``Selects by just whereAnd``() =
+    member _.``Selects by just andWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -360,7 +360,7 @@ type SelectTests () =
             let! fromDb =
                 select {
                     for p in personsView do
-                    whereAnd (p.Position < 2)
+                    andWhere (p.Position < 2)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 1), Seq.head fromDb)
@@ -368,7 +368,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereAnd and whereOr``() =
+    member _.``Selects by andWhere and orWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -381,8 +381,8 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position > 2)
-                    whereAnd (p.Position < 4)
-                    whereOr (p.Position > 9)
+                    andWhere (p.Position < 4)
+                    orWhere (p.Position > 9)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual(2, Seq.length fromDb)

--- a/tests/Dapper.FSharp.Tests/PostgreSQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/PostgreSQL/SelectTests.fs
@@ -306,7 +306,89 @@ type SelectTests () =
             
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
         }
-    
+
+    [<Test>]
+    member _.``Selects by whereAnd``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position > 2)
+                    whereAnd (p.Position < 4)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
+            Assert.AreEqual(1, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by whereOr``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position < 2)
+                    whereOr (p.Position > 8)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual(3, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by just whereAnd``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    whereAnd (p.Position < 2)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual (rs |> List.find (fun x -> x.Position = 1), Seq.head fromDb)
+            Assert.AreEqual(1, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by whereAnd and whereOr``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position > 2)
+                    whereAnd (p.Position < 4)
+                    whereOr (p.Position > 9)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual(2, Seq.length fromDb)
+        }
+
     [<Test>]
     member _.``Selects with order by``() =
         task {

--- a/tests/Dapper.FSharp.Tests/PostgreSQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/PostgreSQL/SelectTests.fs
@@ -308,7 +308,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereAnd``() =
+    member _.``Selects by andWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -321,7 +321,7 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position > 2)
-                    whereAnd (p.Position < 4)
+                    andWhere (p.Position < 4)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
@@ -329,7 +329,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereOr``() =
+    member _.``Selects by orWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -342,14 +342,14 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position < 2)
-                    whereOr (p.Position > 8)
+                    orWhere (p.Position > 8)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual(3, Seq.length fromDb)
         }
 
     [<Test>]
-    member _.``Selects by just whereAnd``() =
+    member _.``Selects by just andWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -361,7 +361,7 @@ type SelectTests () =
             let! fromDb =
                 select {
                     for p in personsView do
-                    whereAnd (p.Position < 2)
+                    andWhere (p.Position < 2)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 1), Seq.head fromDb)
@@ -369,7 +369,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereAnd and whereOr``() =
+    member _.``Selects by andWhere and orWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -382,8 +382,8 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position > 2)
-                    whereAnd (p.Position < 4)
-                    whereOr (p.Position > 9)
+                    andWhere (p.Position < 4)
+                    orWhere (p.Position > 9)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual(2, Seq.length fromDb)

--- a/tests/Dapper.FSharp.Tests/SQLite/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/SQLite/SelectTests.fs
@@ -306,7 +306,89 @@ type SelectTests () =
             
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
         }
-    
+
+    [<Test>]
+    member _.``Selects by whereAnd``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position > 2)
+                    whereAnd (p.Position < 4)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
+            Assert.AreEqual(1, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by whereOr``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position < 2)
+                    whereOr (p.Position > 8)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual(3, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by just whereAnd``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    whereAnd (p.Position < 2)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual (rs |> List.find (fun x -> x.Position = 1), Seq.head fromDb)
+            Assert.AreEqual(1, Seq.length fromDb)
+        }
+
+    [<Test>]
+    member _.``Selects by whereAnd and whereOr``() =
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position > 2)
+                    whereAnd (p.Position < 4)
+                    whereOr (p.Position > 9)
+                } |> conn.SelectAsync<Persons.View>
+
+            Assert.AreEqual(2, Seq.length fromDb)
+        }
+
     [<Test>]
     member _.``Selects with order by``() =
         task {

--- a/tests/Dapper.FSharp.Tests/SQLite/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/SQLite/SelectTests.fs
@@ -308,7 +308,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereAnd``() =
+    member _.``Selects by andWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -321,7 +321,7 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position > 2)
-                    whereAnd (p.Position < 4)
+                    andWhere (p.Position < 4)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 3), Seq.head fromDb)
@@ -329,7 +329,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereOr``() =
+    member _.``Selects by orWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -342,14 +342,14 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position < 2)
-                    whereOr (p.Position > 8)
+                    orWhere (p.Position > 8)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual(3, Seq.length fromDb)
         }
 
     [<Test>]
-    member _.``Selects by just whereAnd``() =
+    member _.``Selects by just andWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -361,7 +361,7 @@ type SelectTests () =
             let! fromDb =
                 select {
                     for p in personsView do
-                    whereAnd (p.Position < 2)
+                    andWhere (p.Position < 2)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual (rs |> List.find (fun x -> x.Position = 1), Seq.head fromDb)
@@ -369,7 +369,7 @@ type SelectTests () =
         }
 
     [<Test>]
-    member _.``Selects by whereAnd and whereOr``() =
+    member _.``Selects by andWhere and orWhere``() =
         task {
             do! init.InitPersons()
             let rs = Persons.View.generate 10
@@ -382,8 +382,8 @@ type SelectTests () =
                 select {
                     for p in personsView do
                     where (p.Position > 2)
-                    whereAnd (p.Position < 4)
-                    whereOr (p.Position > 9)
+                    andWhere (p.Position < 4)
+                    orWhere (p.Position > 9)
                 } |> conn.SelectAsync<Persons.View>
 
             Assert.AreEqual(2, Seq.length fromDb)


### PR DESCRIPTION
This is follow up based on discussion in #89.

Adding new custom operations: `andWhere`, `orWhere`.

They allow combine `WHERE` condition defined so far with new condition.

- multiple `andWhere`, `orWhere` can be used to build complex `WHERE` condition
- first  `andWhere`, `orWhere` without `where` before it behave same way as `where`
- using `where` after  `andWhere`, `orWhere` would replace `WHERE` condition

It's intermediate step towards `andWhereIf`, `orWhereIf` operations, that will be in separate PR and will build on this PR.

