### PR TITLE
andWhereIf, orWhereIf

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,19 @@ select {
 } |> conn.SelectAsync<Person>
 ```
 
+To conditionally add `where` part, you can use `andWhereIf` and `orWhereIf`:
+
+```F#
+let pos = Some 10
+let posOr = Some 2
+select {
+    for p in personTable do
+    where (p.Position > 5)
+    andWhereIf pos.IsSome (p.Position < pos.Value)
+    orWhereIf posOr.IsSome (p.Position < posOr.Value)
+} |> conn.SelectAsync<Person>
+```
+
 NOTE: Do not use the forward pipe `|>` operator in your query expressions because it's not implemented, so don't do it (unless you like exceptions)!
 
 To use LIKE operator in `where` condition, use `like`:

--- a/src/Dapper.FSharp/MSSQL/Builders.fs
+++ b/src/Dapper.FSharp/MSSQL/Builders.fs
@@ -119,6 +119,16 @@ type SelectExpressionBuilder<'T>() =
         let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, Or, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
+    /// Combine existing WHERE condition with AND only if condition is true
+    [<CustomOperation("andWhereIf", MaintainsVariableSpace = true)>]
+    member this.AndWhereIf (state: QuerySource<'T, SelectQuery>, condition: bool, [<ProjectionParameter>] whereExpression ) =
+        if condition then this.AndWhere(state, whereExpression) else state
+
+    /// Combine existing WHERE condition with OR only if condition is true
+    [<CustomOperation("orWhereIf", MaintainsVariableSpace = true)>]
+    member this.OrWhereIf (state: QuerySource<'T, SelectQuery>, condition: bool, [<ProjectionParameter>] whereExpression ) =
+        if condition then this.OrWhere(state, whereExpression) else state
+
     /// Sets the ORDER BY for single column
     [<CustomOperation("orderBy", MaintainsVariableSpace = true)>]
     member this.OrderBy (state:QuerySource<'T>, [<ProjectionParameter>] propertySelector) = 

--- a/src/Dapper.FSharp/MySQL/Builders.fs
+++ b/src/Dapper.FSharp/MySQL/Builders.fs
@@ -117,6 +117,16 @@ type SelectExpressionBuilder<'T>() =
         let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, Or, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
+    /// Combine existing WHERE condition with AND only if condition is true
+    [<CustomOperation("andWhereIf", MaintainsVariableSpace = true)>]
+    member this.AndWhereIf (state: QuerySource<'T, SelectQuery>, condition: bool, [<ProjectionParameter>] whereExpression ) =
+        if condition then this.AndWhere(state, whereExpression) else state
+
+    /// Combine existing WHERE condition with OR only if condition is true
+    [<CustomOperation("orWhereIf", MaintainsVariableSpace = true)>]
+    member this.OrWhereIf (state: QuerySource<'T, SelectQuery>, condition: bool, [<ProjectionParameter>] whereExpression ) =
+        if condition then this.OrWhere(state, whereExpression) else state
+
     /// Sets the ORDER BY for single column
     [<CustomOperation("orderBy", MaintainsVariableSpace = true)>]
     member this.OrderBy (state:QuerySource<'T>, [<ProjectionParameter>] propertySelector) = 

--- a/src/Dapper.FSharp/PostgreSQL/Builders.fs
+++ b/src/Dapper.FSharp/PostgreSQL/Builders.fs
@@ -116,6 +116,16 @@ type SelectExpressionBuilder<'T>() =
         let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, Or, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
+    /// Combine existing WHERE condition with AND only if condition is true
+    [<CustomOperation("andWhereIf", MaintainsVariableSpace = true)>]
+    member this.AndWhereIf (state: QuerySource<'T, SelectQuery>, condition: bool, [<ProjectionParameter>] whereExpression ) =
+        if condition then this.AndWhere(state, whereExpression) else state
+
+    /// Combine existing WHERE condition with OR only if condition is true
+    [<CustomOperation("orWhereIf", MaintainsVariableSpace = true)>]
+    member this.OrWhereIf (state: QuerySource<'T, SelectQuery>, condition: bool, [<ProjectionParameter>] whereExpression ) =
+        if condition then this.OrWhere(state, whereExpression) else state
+
     /// Sets the ORDER BY for single column
     [<CustomOperation("orderBy", MaintainsVariableSpace = true)>]
     member this.OrderBy (state:QuerySource<'T>, [<ProjectionParameter>] propertySelector) = 

--- a/src/Dapper.FSharp/SQLite/Builders.fs
+++ b/src/Dapper.FSharp/SQLite/Builders.fs
@@ -107,6 +107,16 @@ type SelectExpressionBuilder<'T>() =
         let where2 = if state.Query.Where = Where.Empty then state2.Query.Where else Binary(state.Query.Where, Or, state2.Query.Where)
         QuerySource<'T, SelectQuery>( { state.Query with Where = where2 }, state.TableMappings)
 
+    /// Combine existing WHERE condition with AND only if condition is true
+    [<CustomOperation("andWhereIf", MaintainsVariableSpace = true)>]
+    member this.AndWhereIf (state: QuerySource<'T, SelectQuery>, condition: bool, [<ProjectionParameter>] whereExpression ) =
+        if condition then this.AndWhere(state, whereExpression) else state
+
+    /// Combine existing WHERE condition with OR only if condition is true
+    [<CustomOperation("orWhereIf", MaintainsVariableSpace = true)>]
+    member this.OrWhereIf (state: QuerySource<'T, SelectQuery>, condition: bool, [<ProjectionParameter>] whereExpression ) =
+        if condition then this.OrWhere(state, whereExpression) else state
+
     /// Sets the ORDER BY for single column
     [<CustomOperation("orderBy", MaintainsVariableSpace = true)>]
     member this.OrderBy (state:QuerySource<'T>, [<ProjectionParameter>] propertySelector) = 

--- a/tests/Dapper.FSharp.Tests/PostgreSQL/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/PostgreSQL/SelectTests.fs
@@ -389,6 +389,58 @@ type SelectTests () =
             Assert.AreEqual(2, Seq.length fromDb)
         }
 
+    [<TestCase(4)>]
+    [<TestCase(7)>]
+    [<TestCase(2)>]
+    [<TestCase(null)>]
+    member _.``Selects by andWhereIf`` pos =
+        let pos = pos |> Option.ofNullable
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position > 2)
+                    andWhereIf pos.IsSome (p.Position < pos.Value)
+                } |> conn.SelectAsync<Persons.View>
+
+            let expected = rs |> List.filter (fun x -> x.Position > 2 && Option.forall (fun p -> x.Position < p) pos) |> List.length
+            Assert.AreEqual(expected, Seq.length fromDb)
+        }
+
+    [<TestCase(4)>]
+    [<TestCase(7)>]
+    [<TestCase(0)>]
+    [<TestCase(null)>]
+    member _.``Selects by orWhereIf`` pos =
+        let pos = pos |> Option.ofNullable
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position < 2)
+                    orWhereIf pos.IsSome (p.Position > pos.Value)
+                } |> conn.SelectAsync<Persons.View>
+
+            let expected = rs |> List.filter (fun x -> x.Position < 2 || Option.exists (fun p -> x.Position > p) pos) |> List.length
+            Assert.AreEqual(expected, Seq.length fromDb)
+        }
+
     [<Test>]
     member _.``Selects with order by``() =
         task {

--- a/tests/Dapper.FSharp.Tests/SQLite/SelectTests.fs
+++ b/tests/Dapper.FSharp.Tests/SQLite/SelectTests.fs
@@ -389,6 +389,58 @@ type SelectTests () =
             Assert.AreEqual(2, Seq.length fromDb)
         }
 
+    [<TestCase(4)>]
+    [<TestCase(7)>]
+    [<TestCase(2)>]
+    [<TestCase(null)>]
+    member _.``Selects by andWhereIf`` pos =
+        let pos = pos |> Option.ofNullable
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position > 2)
+                    andWhereIf pos.IsSome (p.Position < pos.Value)
+                } |> conn.SelectAsync<Persons.View>
+
+            let expected = rs |> List.filter (fun x -> x.Position > 2 && Option.forall (fun p -> x.Position < p) pos) |> List.length
+            Assert.AreEqual(expected, Seq.length fromDb)
+        }
+
+    [<TestCase(4)>]
+    [<TestCase(7)>]
+    [<TestCase(0)>]
+    [<TestCase(null)>]
+    member _.``Selects by orWhereIf`` pos =
+        let pos = pos |> Option.ofNullable
+        task {
+            do! init.InitPersons()
+            let rs = Persons.View.generate 10
+            let! _ =
+                insert {
+                    into personsView
+                    values rs
+                } |> conn.InsertAsync
+
+            let! fromDb =
+                select {
+                    for p in personsView do
+                    where (p.Position < 2)
+                    orWhereIf pos.IsSome (p.Position > pos.Value)
+                } |> conn.SelectAsync<Persons.View>
+
+            let expected = rs |> List.filter (fun x -> x.Position < 2 || Option.exists (fun p -> x.Position > p) pos) |> List.length
+            Assert.AreEqual(expected, Seq.length fromDb)
+        }
+
     [<Test>]
     member _.``Selects with order by``() =
         task {


### PR DESCRIPTION
Adding new custom operations: `andWhereIf`, `orWhereIf`.

They get `bool` condition as first parameter and acts as `andWhere`, `orWhere` if condition holds and do nothing otherwise.

It allows to optionally extend WHERE condition based on parameters outside of query.

```F#
let pos = Some 10
let posOr = Some 2
select {
    for p in personTable do
    where (p.Position > 5)
    andWhereIf pos.IsSome (p.Position < pos.Value)
    orWhereIf posOr.IsSome (p.Position < posOr.Value)
} |> conn.SelectAsync<Person>
```