### PR TITLE
Fix/106 sqlite string option handler

### DIFF
--- a/src/Dapper.FSharp/SQLite/OptionTypes.fs
+++ b/src/Dapper.FSharp/SQLite/OptionTypes.fs
@@ -30,6 +30,7 @@ type SqliteOptionSByteHandler()          = inherit OptionTypeHandlerWithConverte
 type SqliteOptionTimeSpanHandler()       = inherit OptionTypeHandlerWithParser<TimeSpan>(TimeSpan.Parse)
 type SqliteOptionUInt16Handler()         = inherit OptionTypeHandlerWithConverter<UInt16>(Convert.ToUInt16)
 type SqliteOptionUInt32Handler()         = inherit OptionTypeHandlerWithConverter<UInt32>(Convert.ToUInt32)
+type SqliteOptionStringHandler()         = inherit OptionTypeHandlerWithConverter<String>(Convert.ToString)
 
 let register() =
     SqlMapper.AddTypeHandler(SqliteBooleanHandler())
@@ -57,3 +58,4 @@ let register() =
     SqlMapper.AddTypeHandler(SqliteOptionTimeSpanHandler())
     SqlMapper.AddTypeHandler(SqliteOptionUInt16Handler())
     SqlMapper.AddTypeHandler(SqliteOptionUInt32Handler())
+    SqlMapper.AddTypeHandler(SqliteOptionStringHandler())

--- a/tests/Dapper.FSharp.Tests/Database.fs
+++ b/tests/Dapper.FSharp.Tests/Database.fs
@@ -221,14 +221,6 @@ module Issues =
                     Review = if x % 2 = 1 then Some (sprintf "Review_%i" x) else None
                 })
 
-            let mapToAnon r = 
-                {|
-                    Id = r.Id
-                    Score = r.Score
-                    Username = r.Username
-                    Review = r.Review
-                |}
-
 module Articles =
 
     type View = {

--- a/tests/Dapper.FSharp.Tests/Database.fs
+++ b/tests/Dapper.FSharp.Tests/Database.fs
@@ -17,6 +17,7 @@ type ICrudInitializer =
     abstract member InitDogsWeights : unit -> Task<unit>
     abstract member InitVaccinations : unit -> Task<unit>
     abstract member InitVaccinationManufacturers : unit -> Task<unit>
+    abstract member InitReviews : unit -> Task<unit>
 
 let taskToList (t:Task<seq<'a>>) = t |> Async.AwaitTask |> Async.RunSynchronously |> Seq.toList
 
@@ -199,6 +200,34 @@ module Issues =
                         Desc = sprintf "Desc_%i" x
                     }
                 )
+
+    module Reviews =
+
+        type View = { 
+            Id: int
+            Score: int
+            Username: string
+            Review: string option
+        }
+
+        module View = 
+            let generate x = 
+                [1..x]
+                |> List.map (fun x ->
+                {
+                    Id = x
+                    Score = x % 5
+                    Username = sprintf "Username_%i" x
+                    Review = if x % 2 = 1 then Some (sprintf "Review_%i" x) else None
+                })
+
+            let mapToAnon r = 
+                {|
+                    Id = r.Id
+                    Score = r.Score
+                    Username = r.Username
+                    Review = r.Review
+                |}
 
 module Articles =
 

--- a/tests/Dapper.FSharp.Tests/MSSQL/Database.fs
+++ b/tests/Dapper.FSharp.Tests/MSSQL/Database.fs
@@ -202,6 +202,22 @@ module Issues =
                 return ()
             }
 
+    module Reviews = 
+        let init (conn:IDbConnection) =
+            task {
+                do! "DROP TABLE [dbo].[Reviews]" |> conn.ExecuteIgnore
+                do!
+                    """
+                    create table [dbo].[Reviews](
+                    [Id] [int] NOT NULL,
+                    [Score] [int] NOT NULL,
+                    [Username] [nvarchar](max) NOT NULL,
+                    [Review] [nvarchar](max) NULL
+                    )
+                    """
+                    |> conn.ExecuteIgnore
+                return ()
+            }
 
 let getInitializer (conn:IDbConnection) =
     { new ICrudInitializer with
@@ -215,4 +231,5 @@ let getInitializer (conn:IDbConnection) =
         member x.InitDogsWeights () = DogsWeights.init conn
         member x.InitVaccinations () = Vaccinations.init conn
         member x.InitVaccinationManufacturers () = VaccinationManufacturers.init conn
+        member x.InitReviews () = Issues.Reviews.init conn
     }

--- a/tests/Dapper.FSharp.Tests/MySQL/Database.fs
+++ b/tests/Dapper.FSharp.Tests/MySQL/Database.fs
@@ -206,6 +206,23 @@ module Issues =
                 return ()
             }
 
+    module Reviews = 
+        let init (conn:IDbConnection) =
+            task {
+                do! "drop table Reviews" |> conn.ExecuteIgnore
+                do!
+                    """
+                    create table Reviews(
+                    Id int not null,
+                    Score int not null,
+                    Username nvarchar(63) not null,
+                    Review nvarchar(255) null
+                    )
+                    """
+                    |> conn.ExecuteIgnore
+                return ()
+            }
+
 open Dapper.FSharp.MySQL
 
 let getInitializer (conn:IDbConnection) =
@@ -220,4 +237,5 @@ let getInitializer (conn:IDbConnection) =
         member x.InitDogsWeights () = DogsWeights.init conn
         member x.InitVaccinations () = Vaccinations.init conn
         member x.InitVaccinationManufacturers () = VaccinationManufacturers.init conn
+        member x.InitReviews () = Issues.Reviews.init conn
     }

--- a/tests/Dapper.FSharp.Tests/PostgreSQL/Database.fs
+++ b/tests/Dapper.FSharp.Tests/PostgreSQL/Database.fs
@@ -202,6 +202,23 @@ module Issues =
                 return ()
             }
 
+    module Reviews = 
+        let init (conn:IDbConnection) =
+            task {
+                do! "drop table if exists \"Reviews\"" |> conn.ExecuteIgnore
+                do!
+                    """
+                    create table "Reviews"(
+                    "Id" int not null,
+                    "Score" int not null,
+                    "Username" varchar(63) not null,
+                    "Review" varchar(255) null
+                    )
+                    """
+                    |> conn.ExecuteIgnore
+                return ()
+            }
+
 open Dapper.FSharp.PostgreSQL
 
 let getInitializer (conn:IDbConnection) =
@@ -216,4 +233,5 @@ let getInitializer (conn:IDbConnection) =
         member x.InitDogsWeights () = DogsWeights.init conn
         member x.InitVaccinations () = Vaccinations.init conn
         member x.InitVaccinationManufacturers () = VaccinationManufacturers.init conn
+        member x.InitReviews () = Issues.Reviews.init conn
     }

--- a/tests/Dapper.FSharp.Tests/SQLite/Database.fs
+++ b/tests/Dapper.FSharp.Tests/SQLite/Database.fs
@@ -193,6 +193,23 @@ module Issues =
                 return ()
             }
 
+    module Reviews = 
+        let init (conn:IDbConnection) =
+            task {
+                do! "DROP TABLE IF EXISTS Reviews" |> conn.ExecuteIgnore
+                do!
+                    """
+                    CREATE TABLE [Reviews](
+                    [Id] [INTEGER] NOT NULL,
+                    [Score] [INT] NOT NULL,
+                    [Username] [TEXT] NOT NULL,
+                    [Review] [TEXT] NULL
+                    )
+                    """
+                    |> conn.ExecuteIgnore
+                return ()
+            }
+
 let getInitializer (conn:IDbConnection) =
     { new ICrudInitializer with
         member x.InitPersons () = Persons.init conn
@@ -205,4 +222,5 @@ let getInitializer (conn:IDbConnection) =
         member x.InitDogsWeights () = DogsWeights.init conn
         member x.InitVaccinations () = Vaccinations.init conn
         member x.InitVaccinationManufacturers () = VaccinationManufacturers.init conn
+        member x.InitReviews () = Issues.Reviews.init conn
     }


### PR DESCRIPTION
This PR fixes issue #106 

(For some further clarity on the issue, when looking further into the problem it was when using parameterised queries, and also when "materialising" an object from a select statement. Both test added cover the select part, and I put the non-parameterised test using the standard `select` statement just for good measure)

- Registers a handler for String option type mapping in SQLite
- Adds tests to verify string option types correctly map to and from a nullable text column in SQLite